### PR TITLE
Makefile.am: add target for README to quiet autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,5 @@
 SUBDIRS = src tests
+
+# This is to quiet autotools, which requires that a README is present in the repository.
+# This tells autotools that there is a way to generate the README, even if it does nothing.
+README: README.md


### PR DESCRIPTION
Automake requires that README exist.
It is happy if a target for it exists in `Makefile.am`, even if the target does nothing.