### PR TITLE
Default to loading each source file once

### DIFF
--- a/src/Main/main.cc
+++ b/src/Main/main.cc
@@ -68,7 +68,7 @@ int
 main(int argc, char* argv[])
 {
   //
-  //	Global function declatations
+  //	Global function declarations
   //
   void printBanner(ostream& s);
   void printHelp(const char* name);
@@ -81,13 +81,15 @@ main(int argc, char* argv[])
   bool findPrelude(string& directory, string& fileName);
   void checkForPending();
 
-  bool lineWrapping = true;
-  bool handleCtrlC = true;
-  bool readPrelude = true;
+  bool lineWrapping     = true;
+  bool handleCtrlC      = true;
+  bool readPrelude      = true;
   bool forceInteractive = false;
-  bool outputBanner = true;
+  bool outputBanner     = true;
+  bool loadOnce         = false;
+
   int ansiColor = UNDECIDED;
-  int useTecla = UNDECIDED;
+  int useTecla  = UNDECIDED;
 
   for (int i = 1; i < argc; i++)
     {
@@ -130,6 +132,8 @@ main(int argc, char* argv[])
 	    lineWrapping = false;
 	  else if (strcmp(arg, "-batch") == 0)
 	    handleCtrlC = false;
+	  else if (strcmp(arg, "-repeat-loads") == 0)
+	    loadOnce = true;
 	  else if (strcmp(arg, "-interactive") == 0)
 	    forceInteractive = true;
 	  else if (strcmp(arg, "-print-to-stderr") == 0)
@@ -251,6 +255,7 @@ printHelp(const char* name)
     "  -tecla\t\tUse tecla command line editing\n" <<
     "  -no-tecla\t\tDo not use tecla command line editing\n" <<
     "  -batch\t\tRun in batch mode\n" <<
+    "  -repeat-loads\t\tRe-read file on every `load`\n" <<
     "  -interactive\t\tRun in interactive mode\n" <<
     "  -print-to-stderr\tPrint attribute should use stderr rather than stdout\n" <<
     "  -random-seed=<int>\tSet seed for random number generator\n" <<

--- a/src/Mixfix/lexerAux.cc
+++ b/src/Mixfix/lexerAux.cc
@@ -23,8 +23,9 @@
 //
 //	Auxiliary functions and data needed by lexical analyzer.
 //
-#define MAX_IN_DEPTH	10
+#define MAX_IN_DEPTH	50
 
+int maxInDepthReloads = 10;
 int inStackPtr = 0;
 YY_BUFFER_STATE inStack[MAX_IN_DEPTH];
 int dirMarkerStack[MAX_IN_DEPTH];
@@ -196,7 +197,7 @@ includeFile(const string& directory, const string& fileName, bool silent, int li
       return true;
   }
   loadedFiles.append(relPath);
-  if (!loadOnce && inStackPtr >= MAX_IN_DEPTH)
+  if (!loadOnce && inStackPtr >= maxInDepthReloads)
     {
       IssueWarning(LineNumber(lineNr) <<
 		   ": ins nested too deeply - couldn't open file " <<

--- a/src/Mixfix/lexerAux.cc
+++ b/src/Mixfix/lexerAux.cc
@@ -197,7 +197,9 @@ includeFile(const string& directory, const string& fileName, bool silent, int li
       return true;
   }
   loadedFiles.append(relPath);
-  if (!loadOnce && inStackPtr >= maxInDepthReloads)
+  if (  (inStackPtr >= MAX_IN_DEPTH)
+     || (!loadOnce && inStackPtr >= maxInDepthReloads)
+     )
     {
       IssueWarning(LineNumber(lineNr) <<
 		   ": ins nested too deeply - couldn't open file " <<

--- a/src/Mixfix/lexerAux.cc
+++ b/src/Mixfix/lexerAux.cc
@@ -28,7 +28,9 @@
 int inStackPtr = 0;
 YY_BUFFER_STATE inStack[MAX_IN_DEPTH];
 int dirMarkerStack[MAX_IN_DEPTH];
-Vector<char*> pendingFiles;
+Vector<char*>  pendingFiles;
+Vector<string> loadedFiles;
+bool loadOnce = true;
 int nrPendingRead = 0;
 bool rootInteractive = false;
 bool fakeNewline = false;  // fake \n for files that don't end with \n
@@ -189,7 +191,12 @@ createRootBuffer(FILE* fp, bool forceInteractive)
 bool
 includeFile(const string& directory, const string& fileName, bool silent, int lineNr)
 {
-  if (inStackPtr >= MAX_IN_DEPTH)
+  string relPath = directory + "/" + fileName;
+  if (loadOnce && std::find(loadedFiles.begin(), loadedFiles.end(), relPath) != loadedFiles.end()) {
+      return true;
+  }
+  loadedFiles.append(relPath);
+  if (!loadOnce && inStackPtr >= MAX_IN_DEPTH)
     {
       IssueWarning(LineNumber(lineNr) <<
 		   ": ins nested too deeply - couldn't open file " <<


### PR DESCRIPTION
Original behavior was to reload files every time they are loaded (to allow some sort of rough parameterization).

None of the code present uses this style of parameterization, and I suspect that very little code does.

Old behaviour is preserved with option `-repeat-loads`.

@skeirik2 what do you think?