### PR TITLE
Update `eqform`, a simpler `foform`

### DIFF
--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -157,10 +157,18 @@ fmod EQFORM is
   subsort EqForm TrivTrueForm  < Eq+TrivTrueForm  < NoFalseForm      NormForm .
   subsort EqForm TrivFalseForm < Eq+TrivFalseForm < NoTrueForm       NormForm .
 
+  --- add these subsorts and (op ~_ : Lit -> NonTrivLit) to get proper literals
+  sort NonTrivLit NoFalseLit NoTrueLit Lit .
+  subsort EqLit < NonTrivLit < NonTrivForm .
+  subsort NormLit NoFalseLit NoTrueLit < Lit < Form .
+  subsort NonTrivLit Eq+TrueLit  < NoFalseLit < NoFalseForm .
+  subsort NonTrivLit Eq+FalseLit < NoTrueLit  < NoTrueForm  .
+
   op tt   :           -> TrueLit     [ctor] .
   op ff   :           -> FalseLit    [ctor] .
   op _?=_ : Term Term -> PosEqLit    [ctor prec 50] .
   op _!=_ : Term Term -> NegEqLit    [ctor prec 50] .
+  op ~_   : Lit       -> NonTrivLit  [ctor prec 51] .
   op ~_   : Form      -> NonTrivForm [ctor prec 51] .
 
   op _/\_ : TrivTrueForm   TrivTrueForm   -> TrivTrueForm  [ctor assoc comm id: tt prec 52] .

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -211,12 +211,20 @@ fmod EQFORM is
   --- op _/\_ : TrivFalseForm Form -> Form [ditto] .
   --- op _\/_ : TrivFalseForm Form -> Form [ditto] .
   --- op _\/_ : TrivTrueForm  Form -> Form [ditto] .
+  --------------------------------------------------
 
+  var EqL : EqLit .
   vars F F' : Form .
   vars CF CG : NoTrueForm .
   vars DF DG : NoFalseForm .
   vars T T' : Term .
   var SUB : Substitution .
+
+  eq ff /\ EqL = ff .
+  eq tt \/ EqL = tt .
+
+  eq EqL /\ EqL = EqL .
+  eq EqL \/ EqL = EqL .
 
   --- Implication
   op _=>_  : Form Form -> Form .

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -31,27 +31,26 @@ purposes:
 -   `NoTrueForm`  - `NonTrivForm` or `TrueLit`
 -   `NoFalseForm` - `NonTrivForm` or `FalseLit`
 
-Q:  Why are these seemingly weird sorts needed?
+Q: Why are these seemingly weird sorts needed?
 
-A:  Because `tt` and `ff` are actually _identities_ for the operators `/\` and
-    `\/` respectively. Sorts `NoTrueForm` and `NoFalseForm` allow us to recurse
-    properly inside a `/\` or `\/` operator respectively because they forbid
-    their respective identities from appearing. If we forget to use them and use
-    variables of sort Form instead, with very high probability, the code will
-    fail to terminate, e.g. if the equation (a) `g(F /\ G) = g(F) /\ g(G)` has
-    variables `F` and `G` of sort `Form`, when we write `g(S ?= T)`, then (a)
-    will apply because `S ?= T` equals `S ?= T /\ tt` by the identity laws, so
-    that, `g(S ?= T)` equals `g(S ?= T) /\ g(tt)`.
+A: Because `tt` and `ff` are actually _identities_ for the operators `/\` and
+`\/` respectively. Sorts `NoTrueForm` and `NoFalseForm` allow us to recurse
+properly inside a `/\` or `\/` operator respectively because they forbid their
+respective identities from appearing. If we forget to use them and use variables
+of sort Form instead, with very high probability, the code will not terminate,
+e.g. if the equation (a) `g(F /\ G) = g(F) /\ g(G)` has variables `F` and `G` of
+sort `Form`, when we write `g(S ?= T)`, then equation (a) will apply because
+`S ?= T` equals `S ?= T /\ tt` by the identity laws, so that, `g(S ?= T)` equals
+`g(S ?= T) /\ g(tt)`.
 
-    On the other hand, the fact that `/\` and `\/` are also sets allows us to
-    extract certain subformulas directly using pattern matching alone. When we
-    are performing operations over these operators as sets, we use `tt` and `ff`
-    as the set identity operators respectively.
+On the other hand, the fact that `/\` and `\/` are also sets allows us to
+extract certain subformulas directly using pattern matching alone. When we are
+performing operations over these operators as sets, we use `tt` and `ff` as the
+set identity operators respectively.
 
-    See the NNF module below to see how to traverse over formulas as TREES. See
-    the NEF, DNF, and CNF modules below for more SET-like examples. Note that
-    NEF stands for Normal Equational Form. It converts formulas of type Form
-    into type NormForm.
+See the NNF module below to see how to traverse over formulas as TREES. See the
+NEF, DNF, and CNF modules below for more SET-like examples. Note NEF stands for
+Normal Equational Form. It converts formulas of type Form into type NormForm.
 
 [1] More precisely, these claims depend on the underlying formula structure. If
 it exposes positive and negative equality literals, as we do, then alll claims

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -212,11 +212,18 @@ fmod EQFORM is
   --- op _\/_ : TrivFalseForm Form -> Form [ditto] .
   --- op _\/_ : TrivTrueForm  Form -> Form [ditto] .
 
-  var F : Form .
+  vars F F' : Form .
   vars CF CG : NoTrueForm .
   vars DF DG : NoFalseForm .
   vars T T' : Term .
   var SUB : Substitution .
+
+  --- Implication
+  op _=>_  : Form Form -> Form .
+  op _<=>_ : Form Form -> Form .
+  ------------------------------
+  eq F  => F' = (~ F) \/ F' .
+  eq F <=> F' = (F => F') /\ (F' => F) .
 
   op _<<_ : Form Substitution -> Form .
   -------------------------------------

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -1,49 +1,65 @@
 Equational Formulas
 ===================
 
-For theorem proving purposes with equational logic, there are essentially three kinds of quantifier free formulas that we care about:
+For theorem proving purposes with equational logic, there are essentially three
+kinds of quantifier free formulas that we care about:
 
-1.  true
-2.  false
-3.  any formula without true, false, or negation
+-   true
+-   false
+-   any formula without true, false, or negation [1]
 
 This follows because:
 
--   any formula with negation is equivalent to one without negation
--   any formula without negation is equivalent to a formula in one of the three cases above by evaluating away true and false
+-   any formula with negation is logically equivalent to one without negation
+-   any formula without negation is logically equivalent to a formula in one of
+    the three cases above by evaluating away true and false [1]
 
 This library provides formula sorts to cover these core cases and more:
 
-4.  `True`     - the sort of the formula in case [1] above
-5.  `False`    - the sort of the formula in case [2] above
-6.  `EqLit`    - positive (`_?=_`) or (`_!=_`) negative equality literals
-7.  `EqForm`   - the sort of formulas in case [3] above
-8.  `NormForm` - the sort containing all formulas in cases [1-3] above
-9.  `Form`     - the sort of all quantifier-free equational formulas
+-   `TrueLit`  - the formula `tt`, i.e. the true literal
+-   `FalseLit` - the formula `ff`, i.e. the false literal
+-   `EqLit`    - positive `_?=_` or `_!=_` negative equality literals
+-   `EqForm`   - recursive applications of `/\` and `\/` over `EqLit`formulas
+-   `NormForm` - `TrueLit`, `FalseLit`, or `EqForm`
+-   `Form`     - the sort of all quantifier-free equational formulas
 
-This library also provides other formula sorts that are needed for programming purposes:
+This library also provides other formula sorts that are needed for programming
+purposes:
 
-10. `NoTrueForm`  - Formulas over ...
-11. `NoFalseForm` - Formulas over ...
+-   `NonTrivForm` - syntactically non-trivial formulas, i.e. formulas that
+                    do not evaluate to `tt` or `ff` by identity equations alone
+-   `NoTrueForm`  - `NonTrivForm` or `TrueLit`
+-   `NoFalseForm` - `NonTrivForm` or `FalseLit`
 
 Q:  Why are these seemingly weird sorts needed?
 
-A:  Because true and false are actually _identities_ for the operators
-    `/\` and `\/` respectively. Sorts [12] and [13] allow us to recurse properly
-    inside a `/\` or `\/` operator respectively because they forbid their
-    respective identities from appearing. If we forget to use them and use
-    variables of sort Form instead, with very high probability, the code
-    will fail to terminate.
+A:  Because `tt` and `ff` are actually _identities_ for the operators `/\` and
+    `\/` respectively. Sorts `NoTrueForm` and `NoFalseForm` allow us to recurse
+    properly inside a `/\` or `\/` operator respectively because they forbid
+    their respective identities from appearing. If we forget to use them and use
+    variables of sort Form instead, with very high probability, the code will
+    fail to terminate, e.g. if the equation (a) `g(F /\ G) = g(F) /\ g(G)` has
+    variables `F` and `G` of sort `Form`, when we write `g(S ?= T)`, then (a)
+    will apply because `S ?= T` equals `S ?= T /\ tt` by the identity laws, so
+    that, `g(S ?= T)` equals `g(S ?= T) /\ g(tt)`.
 
     On the other hand, the fact that `/\` and `\/` are also sets allows us to
-    extract certain subformulas directly using pattern matching alone. When
-    we are performing operations over these operators as sets, we use true
-    and false as the set identity operators respectively.
+    extract certain subformulas directly using pattern matching alone. When we
+    are performing operations over these operators as sets, we use `tt` and `ff`
+    as the set identity operators respectively.
 
-    See the NNF module below to see how to traverse over formulas as TREES.
-    See the NEF, DNF, and CNF modules below for more SET-like examples.
-    Note that NEF stands for Normal Equational Form. It converts formulas
-    of type Form into type NormForm.
+    See the NNF module below to see how to traverse over formulas as TREES. See
+    the NEF, DNF, and CNF modules below for more SET-like examples. Note that
+    NEF stands for Normal Equational Form. It converts formulas of type Form
+    into type NormForm.
+
+[1] More precisely, these claims depend on the underlying formula structure. If
+it exposes positive and negative equality literals, as we do, then alll claims
+hold. If the negative equality literal is represented by negating a positive
+equality literal, then negations cannot be totally evaluated away; in that case,
+one would consider a formula to be normalized if it (a) true and false literals
+did not appear anywhere (b) negation only appeared directly above a positive
+equality literal.
 
 Style Notes
 -----------
@@ -71,23 +87,23 @@ Currently, this list includes:
 -   Lists of formulas
 -   Sets of formulas
 
-Note that, due to preregularity requirements, the number of sorts grows
-in a multiplicative fashion every time one applies a functor to the
-formula data strcuture. For this reason, to avoid generating many unneeded
-sorts, we only generate functor liftings for:
+Note that, due to preregularity requirements, the number of sorts grows in a
+multiplicative fashion every time one applies a functor to the formula data
+strcuture. For this reason, to avoid generating many unneeded sorts, we only
+generate functor liftings for:
 
-A.  Subsorts of EqForm (12 sorts in total)
-B.  NormForm
-C.  Form
+-   Subsorts of `EqForm` (12 sorts in total)
+-   `NormForm`
+-   `Form`
 
 In practice, these are the primary cases that we care about, due to the
 considerations mentioned above.
 
 Note: many data functors (such as list and set) generate a unique sort for
 non-empty and possibly empty data structures, so that we actually generate
-2 * N + 1 additional sorts each time, where the extra sort comes from a
-base sort which helps ensure preregularity in complex cases (this gives
-29 sorts generated for both the list and set functor assuming the 14 above).
+2 * N + 1 additional sorts each time, where the extra sort comes from a base
+sort which helps ensure preregularity in complex cases (this gives 29 sorts
+generated for both the list and set functor assuming the 14 above).
 
 ```maude
 load terms.maude
@@ -98,25 +114,25 @@ fmod EQFORM is
   pr META-TERM .
   pr SUBSTITUTION-SET .
 
-  sort TrueLit  FalseLit        .
-  sort PosEqLit NegEqLit EqLit  .
-  sort PosConj  NegConj  EqConj .
-  sort PosDisj  NegDisj  EqDisj .
-  sort PosForm  NegForm  EqForm .
+  sort TrueLit   FalseLit         .
+  sort PosEqLit  NegEqLit  EqLit  .
+  sort PosEqConj NegEqConj EqConj .
+  sort PosEqDisj NegEqDisj EqDisj .
+  sort PosEqForm NegEqForm EqForm .
 
   subsort PosEqLit NegEqLit < EqLit .
   ---
-  subsort PosEqLit < PosConj PosDisj .
-  subsort NegEqLit < NegConj NegDisj .
-  subsort EqLit    < EqConj  EqDisj  .
+  subsort PosEqLit < PosEqConj PosEqDisj .
+  subsort NegEqLit < NegEqConj NegEqDisj .
+  subsort EqLit    < EqConj    EqDisj    .
   ---
-  subsort PosConj NegConj < EqConj .
-  subsort PosDisj NegDisj < EqDisj .
-  subsort PosForm NegForm < EqForm .
+  subsort PosEqConj NegEqConj < EqConj .
+  subsort PosEqDisj NegEqDisj < EqDisj .
+  subsort PosEqForm NegEqForm < EqForm .
   ---
-  subsort PosConj PosDisj < PosForm .
-  subsort NegConj NegDisj < NegForm .
-  subsort EqConj  EqDisj  < EqForm  .
+  subsort PosEqConj PosEqDisj < PosEqForm .
+  subsort NegEqConj NegEqDisj < NegEqForm .
+  subsort EqConj    EqDisj    < EqForm    .
 
   sort TrivTrueForm TrivFalseForm NonTrivForm .
   subsort TrueLit  < TrivTrueForm  .
@@ -148,11 +164,11 @@ fmod EQFORM is
   op _/\_ : TrivTrueForm   NonTrivForm    -> NonTrivForm   [ditto] .
   op _/\_ : TrivFalseForm  NonTrivForm    -> NonTrivForm   [ditto] .
   ---
-  op _/\_ : PosConj        PosConj        -> PosConj       [ditto] .
-  op _/\_ : NegConj        NegConj        -> NegConj       [ditto] .
+  op _/\_ : PosEqConj      PosEqConj      -> PosEqConj     [ditto] .
+  op _/\_ : NegEqConj      NegEqConj      -> NegEqConj     [ditto] .
   op _/\_ : EqConj         EqConj         -> EqConj        [ditto] .
-  op _/\_ : PosForm        PosForm        -> PosForm       [ditto] .
-  op _/\_ : NegForm        NegForm        -> NegForm       [ditto] .
+  op _/\_ : PosEqForm      PosEqForm      -> PosEqForm     [ditto] .
+  op _/\_ : NegEqForm      NegEqForm      -> NegEqForm     [ditto] .
   op _/\_ : EqForm         EqForm         -> EqForm        [ditto] .
   op _/\_ : NonTrivForm    NonTrivForm    -> NonTrivForm   [ditto] .
   op _/\_ : Form           Form           -> Form          [ditto] .
@@ -164,11 +180,11 @@ fmod EQFORM is
   op _\/_ : TrivFalseForm  NonTrivForm    -> NonTrivForm   [ditto] .
   op _\/_ : TrivTrueForm   NonTrivForm    -> NonTrivForm   [ditto] .
   ---
-  op _\/_ : PosDisj        PosDisj        -> PosDisj       [ditto] .
-  op _\/_ : NegDisj        NegDisj        -> NegDisj       [ditto] .
+  op _\/_ : PosEqDisj      PosEqDisj      -> PosEqDisj     [ditto] .
+  op _\/_ : NegEqDisj      NegEqDisj      -> NegEqDisj     [ditto] .
   op _\/_ : EqDisj         EqDisj         -> EqDisj        [ditto] .
-  op _\/_ : PosForm        PosForm        -> PosForm       [ditto] .
-  op _\/_ : NegForm        NegForm        -> NegForm       [ditto] .
+  op _\/_ : PosEqForm      PosEqForm      -> PosEqForm     [ditto] .
+  op _\/_ : NegEqForm      NegEqForm      -> NegEqForm     [ditto] .
   op _\/_ : EqForm         EqForm         -> EqForm        [ditto] .
   op _\/_ : NonTrivForm    NonTrivForm    -> NonTrivForm   [ditto] .
   op _\/_ : Form           Form           -> Form          [ditto] .
@@ -302,24 +318,24 @@ fmod EQFORM-LIST is
   pr EQFORM .
 
   sort EmptyFormList .
-  sort PosEqLitList PosConjList PosDisjList PosFormList .
-  sort NegEqLitList NegConjList NegDisjList NegFormList .
+  sort PosEqLitList PosEqConjList PosEqDisjList PosEqFormList .
+  sort NegEqLitList NegEqConjList NegEqDisjList NegEqFormList .
   sort EqLitList    EqConjList    EqDisjList    EqFormList    .
   sort NormFormList FormList .
 
-  sort PosEqLitNeList PosConjNeList PosDisjNeList PosFormNeList .
-  sort NegEqLitNeList NegConjNeList NegDisjNeList NegFormNeList .
+  sort PosEqLitNeList PosEqConjNeList PosEqDisjNeList PosEqFormNeList .
+  sort NegEqLitNeList NegEqConjNeList NegEqDisjNeList NegEqFormNeList .
   sort EqLitNeList    EqConjNeList    EqDisjNeList    EqFormNeList    .
   sort NormFormNeList FormNeList .
 
   subsort PosEqLit  < PosEqLitNeList  < PosEqLitList  .
-  subsort PosConj < PosConjNeList < PosConjList .
-  subsort PosDisj < PosDisjNeList < PosDisjList .
-  subsort PosForm < PosFormNeList < PosFormList .
+  subsort PosEqConj < PosEqConjNeList < PosEqConjList .
+  subsort PosEqDisj < PosEqDisjNeList < PosEqDisjList .
+  subsort PosEqForm < PosEqFormNeList < PosEqFormList .
   subsort NegEqLit  < NegEqLitNeList  < NegEqLitList  .
-  subsort NegConj < NegConjNeList < NegConjList .
-  subsort NegDisj < NegDisjNeList < NegDisjList .
-  subsort NegForm < NegFormNeList < NegFormList .
+  subsort NegEqConj < NegEqConjNeList < NegEqConjList .
+  subsort NegEqDisj < NegEqDisjNeList < NegEqDisjList .
+  subsort NegEqForm < NegEqFormNeList < NegEqFormList .
   subsort EqLit     < EqLitNeList     < EqLitList     .
   subsort EqConj    < EqConjNeList    < EqConjList    .
   subsort EqDisj    < EqDisjNeList    < EqDisjList    .
@@ -328,103 +344,103 @@ fmod EQFORM-LIST is
   subsort Form      < FormNeList      < FormList      .
 
   --- List Functor
-  --- Apply Pos/Neg Functor To Sorts
+  --- Apply PosEq/NegEq Functor To Sorts
   subsort PosEqLitList  NegEqLitList  < EqLitList  .
-  subsort PosConjList NegConjList < EqConjList .
-  subsort PosDisjList NegDisjList < EqDisjList .
-  subsort PosFormList NegFormList < EqFormList .
-  --- Apply Pos/Neg Functor To Subsort Arrows
-  subsort PosEqLitList < PosConjList PosDisjList < PosFormList .
-  subsort NegEqLitList < NegConjList NegDisjList < NegFormList .
+  subsort PosEqConjList NegEqConjList < EqConjList .
+  subsort PosEqDisjList NegEqDisjList < EqDisjList .
+  subsort PosEqFormList NegEqFormList < EqFormList .
+  --- Apply PosEq/NegEq Functor To Subsort Arrows
+  subsort PosEqLitList < PosEqConjList PosEqDisjList < PosEqFormList .
+  subsort NegEqLitList < NegEqConjList NegEqDisjList < NegEqFormList .
   subsort EqLitList    < EqConjList    EqDisjList    < EqFormList    .
   --- Other Cases
   subsort EmptyFormList < PosEqLitList NegEqLitList FormList .
   subsort EqFormList < NormFormList < FormList .
 
   --- NeList Functor
-  --- Apply Pos/Neg Functor To Sorts
+  --- Apply PosEq/NegEq Functor To Sorts
   subsort PosEqLitNeList  NegEqLitNeList  < EqLitNeList  .
-  subsort PosConjNeList NegConjNeList < EqConjNeList .
-  subsort PosDisjNeList NegDisjNeList < EqDisjNeList .
-  subsort PosFormNeList NegFormNeList < EqFormNeList .
-  --- Apply Pos/Neg Functor To Subsort Arrows
-  subsort PosEqLitNeList < PosConjNeList PosDisjNeList < PosFormNeList .
-  subsort NegEqLitNeList < NegConjNeList NegDisjNeList < NegFormNeList .
+  subsort PosEqConjNeList NegEqConjNeList < EqConjNeList .
+  subsort PosEqDisjNeList NegEqDisjNeList < EqDisjNeList .
+  subsort PosEqFormNeList NegEqFormNeList < EqFormNeList .
+  --- Apply PosEq/NegEq Functor To Subsort Arrows
+  subsort PosEqLitNeList < PosEqConjNeList PosEqDisjNeList < PosEqFormNeList .
+  subsort NegEqLitNeList < NegEqConjNeList NegEqDisjNeList < NegEqFormNeList .
   subsort EqLitNeList    < EqConjNeList    EqDisjNeList    < EqFormNeList    .
   --- Other Cases
   subsort EqFormNeList < NormFormNeList < FormNeList .
 
-  op mtFormList :                            -> EmptyFormList   [ctor] .
-  op (_;_) : EmptyFormList   EmptyFormList   -> EmptyFormList   [ctor assoc id: mtFormList] .
+  op mtFormList :                              -> EmptyFormList   [ctor] .
+  op (_;_) : EmptyFormList    EmptyFormList    -> EmptyFormList   [ctor assoc id: mtFormList] .
 
-  op (_;_) : PosEqLitList    PosEqLitList    -> PosEqLitList    [ctor ditto] .
-  op (_;_) : PosConjList   PosConjList   -> PosConjList   [ctor ditto] .
-  op (_;_) : PosDisjList   PosDisjList   -> PosDisjList   [ctor ditto] .
-  op (_;_) : PosFormList   PosFormList   -> PosFormList   [ctor ditto] .
-  op (_;_) : NegEqLitList    NegEqLitList    -> NegEqLitList    [ctor ditto] .
-  op (_;_) : NegConjList   NegConjList   -> NegConjList   [ctor ditto] .
-  op (_;_) : NegDisjList   NegDisjList   -> NegDisjList   [ctor ditto] .
-  op (_;_) : NegFormList   NegFormList   -> NegFormList   [ctor ditto] .
-  op (_;_) : EqLitList       EqLitList       -> EqLitList       [ctor ditto] .
-  op (_;_) : EqConjList      EqConjList      -> EqConjList      [ctor ditto] .
-  op (_;_) : EqDisjList      EqDisjList      -> EqDisjList      [ctor ditto] .
-  op (_;_) : EqFormList      EqFormList      -> EqFormList      [ctor ditto] .
-  op (_;_) : NormFormList    NormFormList    -> NormFormList    [ctor ditto] .
-  op (_;_) : FormList        FormList        -> FormList        [ctor ditto] .
+  op (_;_) : PosEqLitList     PosEqLitList     -> PosEqLitList    [ctor ditto] .
+  op (_;_) : PosEqConjList    PosEqConjList    -> PosEqConjList   [ctor ditto] .
+  op (_;_) : PosEqDisjList    PosEqDisjList    -> PosEqDisjList   [ctor ditto] .
+  op (_;_) : PosEqFormList    PosEqFormList    -> PosEqFormList   [ctor ditto] .
+  op (_;_) : NegEqLitList     NegEqLitList     -> NegEqLitList    [ctor ditto] .
+  op (_;_) : NegEqConjList    NegEqConjList    -> NegEqConjList   [ctor ditto] .
+  op (_;_) : NegEqDisjList    NegEqDisjList    -> NegEqDisjList   [ctor ditto] .
+  op (_;_) : NegEqFormList    NegEqFormList    -> NegEqFormList   [ctor ditto] .
+  op (_;_) : EqLitList        EqLitList        -> EqLitList       [ctor ditto] .
+  op (_;_) : EqConjList       EqConjList       -> EqConjList      [ctor ditto] .
+  op (_;_) : EqDisjList       EqDisjList       -> EqDisjList      [ctor ditto] .
+  op (_;_) : EqFormList       EqFormList       -> EqFormList      [ctor ditto] .
+  op (_;_) : NormFormList     NormFormList     -> NormFormList    [ctor ditto] .
+  op (_;_) : FormList         FormList         -> FormList        [ctor ditto] .
 
-  op (_;_) : PosEqLitNeList  PosEqLitList    -> PosEqLitNeList  [ctor ditto] .
-  op (_;_) : PosConjNeList PosConjList   -> PosConjNeList [ctor ditto] .
-  op (_;_) : PosDisjNeList PosDisjList   -> PosDisjNeList [ctor ditto] .
-  op (_;_) : PosFormNeList PosFormList   -> PosFormNeList [ctor ditto] .
-  op (_;_) : NegEqLitNeList  NegEqLitList    -> NegEqLitNeList  [ctor ditto] .
-  op (_;_) : NegConjNeList NegConjList   -> NegConjNeList [ctor ditto] .
-  op (_;_) : NegDisjNeList NegDisjList   -> NegDisjNeList [ctor ditto] .
-  op (_;_) : NegFormNeList NegFormList   -> NegFormNeList [ctor ditto] .
-  op (_;_) : EqLitNeList     EqLitList       -> EqLitNeList     [ctor ditto] .
-  op (_;_) : EqConjNeList    EqConjList      -> EqConjNeList    [ctor ditto] .
-  op (_;_) : EqDisjNeList    EqDisjList      -> EqDisjNeList    [ctor ditto] .
-  op (_;_) : EqFormNeList    EqFormList      -> EqFormNeList    [ctor ditto] .
-  op (_;_) : NormFormNeList  NormFormList    -> NormFormNeList  [ctor ditto] .
-  op (_;_) : FormNeList      FormList        -> FormNeList      [ctor ditto] .
+  op (_;_) : PosEqLitNeList   PosEqLitList     -> PosEqLitNeList  [ctor ditto] .
+  op (_;_) : PosEqConjNeList  PosEqConjList    -> PosEqConjNeList [ctor ditto] .
+  op (_;_) : PosEqDisjNeList  PosEqDisjList    -> PosEqDisjNeList [ctor ditto] .
+  op (_;_) : PosEqFormNeList  PosEqFormList    -> PosEqFormNeList [ctor ditto] .
+  op (_;_) : NegEqLitNeList   NegEqLitList     -> NegEqLitNeList  [ctor ditto] .
+  op (_;_) : NegEqConjNeList  NegEqConjList    -> NegEqConjNeList [ctor ditto] .
+  op (_;_) : NegEqDisjNeList  NegEqDisjList    -> NegEqDisjNeList [ctor ditto] .
+  op (_;_) : NegEqFormNeList  NegEqFormList    -> NegEqFormNeList [ctor ditto] .
+  op (_;_) : EqLitNeList      EqLitList        -> EqLitNeList     [ctor ditto] .
+  op (_;_) : EqConjNeList     EqConjList       -> EqConjNeList    [ctor ditto] .
+  op (_;_) : EqDisjNeList     EqDisjList       -> EqDisjNeList    [ctor ditto] .
+  op (_;_) : EqFormNeList     EqFormList       -> EqFormNeList    [ctor ditto] .
+  op (_;_) : NormFormNeList   NormFormList     -> NormFormNeList  [ctor ditto] .
+  op (_;_) : FormNeList       FormList         -> FormNeList      [ctor ditto] .
 
-  op (_;_) : PosEqLitList    PosEqLitNeList  -> PosEqLitNeList  [ctor ditto] .
-  op (_;_) : PosConjList   PosConjNeList -> PosConjNeList [ctor ditto] .
-  op (_;_) : PosDisjList   PosDisjNeList -> PosDisjNeList [ctor ditto] .
-  op (_;_) : PosFormList   PosFormNeList -> PosFormNeList [ctor ditto] .
-  op (_;_) : NegEqLitList    NegEqLitNeList  -> NegEqLitNeList  [ctor ditto] .
-  op (_;_) : NegConjList   NegConjNeList -> NegConjNeList [ctor ditto] .
-  op (_;_) : NegDisjList   NegDisjNeList -> NegDisjNeList [ctor ditto] .
-  op (_;_) : NegFormList   NegFormNeList -> NegFormNeList [ctor ditto] .
-  op (_;_) : EqLitList       EqLitNeList     -> EqLitNeList     [ctor ditto] .
-  op (_;_) : EqConjList      EqConjNeList    -> EqConjNeList    [ctor ditto] .
-  op (_;_) : EqDisjList      EqDisjNeList    -> EqDisjNeList    [ctor ditto] .
-  op (_;_) : EqFormList      EqFormNeList    -> EqFormNeList    [ctor ditto] .
-  op (_;_) : NormFormList    NormFormNeList  -> NormFormNeList  [ctor ditto] .
-  op (_;_) : FormList        FormNeList      -> FormNeList      [ctor ditto] .
+  op (_;_) : PosEqLitList     PosEqLitNeList   -> PosEqLitNeList  [ctor ditto] .
+  op (_;_) : PosEqConjList    PosEqConjNeList  -> PosEqConjNeList [ctor ditto] .
+  op (_;_) : PosEqDisjList    PosEqDisjNeList  -> PosEqDisjNeList [ctor ditto] .
+  op (_;_) : PosEqFormList    PosEqFormNeList  -> PosEqFormNeList [ctor ditto] .
+  op (_;_) : NegEqLitList     NegEqLitNeList   -> NegEqLitNeList  [ctor ditto] .
+  op (_;_) : NegEqConjList    NegEqConjNeList  -> NegEqConjNeList [ctor ditto] .
+  op (_;_) : NegEqDisjList    NegEqDisjNeList  -> NegEqDisjNeList [ctor ditto] .
+  op (_;_) : NegEqFormList    NegEqFormNeList  -> NegEqFormNeList [ctor ditto] .
+  op (_;_) : EqLitList        EqLitNeList      -> EqLitNeList     [ctor ditto] .
+  op (_;_) : EqConjList       EqConjNeList     -> EqConjNeList    [ctor ditto] .
+  op (_;_) : EqDisjList       EqDisjNeList     -> EqDisjNeList    [ctor ditto] .
+  op (_;_) : EqFormList       EqFormNeList     -> EqFormNeList    [ctor ditto] .
+  op (_;_) : NormFormList     NormFormNeList   -> NormFormNeList  [ctor ditto] .
+  op (_;_) : FormList         FormNeList       -> FormNeList      [ctor ditto] .
 endfm
 
 fmod EQFORM-SET is
   pr EQFORM .
 
   sort EmptyFormSet .
-  sort PosEqLitSet PosConjSet PosDisjSet PosFormSet .
-  sort NegEqLitSet NegConjSet NegDisjSet NegFormSet .
+  sort PosEqLitSet PosEqConjSet PosEqDisjSet PosEqFormSet .
+  sort NegEqLitSet NegEqConjSet NegEqDisjSet NegEqFormSet .
   sort EqLitSet    EqConjSet    EqDisjSet    EqFormSet    .
   sort NormFormSet FormSet .
 
-  sort PosEqLitNeSet PosConjNeSet PosDisjNeSet PosFormNeSet .
-  sort NegEqLitNeSet NegConjNeSet NegDisjNeSet NegFormNeSet .
+  sort PosEqLitNeSet PosEqConjNeSet PosEqDisjNeSet PosEqFormNeSet .
+  sort NegEqLitNeSet NegEqConjNeSet NegEqDisjNeSet NegEqFormNeSet .
   sort EqLitNeSet    EqConjNeSet    EqDisjNeSet    EqFormNeSet    .
   sort NormFormNeSet FormNeSet .
 
   subsort PosEqLit  < PosEqLitNeSet  < PosEqLitSet  .
-  subsort PosConj < PosConjNeSet < PosConjSet .
-  subsort PosDisj < PosDisjNeSet < PosDisjSet .
-  subsort PosForm < PosFormNeSet < PosFormSet .
+  subsort PosEqConj < PosEqConjNeSet < PosEqConjSet .
+  subsort PosEqDisj < PosEqDisjNeSet < PosEqDisjSet .
+  subsort PosEqForm < PosEqFormNeSet < PosEqFormSet .
   subsort NegEqLit  < NegEqLitNeSet  < NegEqLitSet  .
-  subsort NegConj < NegConjNeSet < NegConjSet .
-  subsort NegDisj < NegDisjNeSet < NegDisjSet .
-  subsort NegForm < NegFormNeSet < NegFormSet .
+  subsort NegEqConj < NegEqConjNeSet < NegEqConjSet .
+  subsort NegEqDisj < NegEqDisjNeSet < NegEqDisjSet .
+  subsort NegEqForm < NegEqFormNeSet < NegEqFormSet .
   subsort EqLit     < EqLitNeSet     < EqLitSet     .
   subsort EqConj    < EqConjNeSet    < EqConjSet    .
   subsort EqDisj    < EqDisjNeSet    < EqDisjSet    .
@@ -433,63 +449,63 @@ fmod EQFORM-SET is
   subsort Form      < FormNeSet      < FormSet      .
 
   --- Set Functor
-  --- Apply Pos/Neg Functor To Sorts
+  --- Apply PosEq/NegEq Functor To Sorts
   subsort PosEqLitSet  NegEqLitSet  < EqLitSet  .
-  subsort PosConjSet NegConjSet < EqConjSet .
-  subsort PosDisjSet NegDisjSet < EqDisjSet .
-  subsort PosFormSet NegFormSet < EqFormSet .
-  --- Apply Pos/Neg Functor To Subsort Arrows
-  subsort PosEqLitSet < PosConjSet PosDisjSet < PosFormSet .
-  subsort NegEqLitSet < NegConjSet NegDisjSet < NegFormSet .
+  subsort PosEqConjSet NegEqConjSet < EqConjSet .
+  subsort PosEqDisjSet NegEqDisjSet < EqDisjSet .
+  subsort PosEqFormSet NegEqFormSet < EqFormSet .
+  --- Apply PosEq/NegEq Functor To Subsort Arrows
+  subsort PosEqLitSet < PosEqConjSet PosEqDisjSet < PosEqFormSet .
+  subsort NegEqLitSet < NegEqConjSet NegEqDisjSet < NegEqFormSet .
   subsort EqLitSet    < EqConjSet    EqDisjSet    < EqFormSet    .
   --- Other Cases
   subsort EmptyFormSet < PosEqLitSet NegEqLitSet FormSet .
   subsort EqFormSet < NormFormSet < FormSet .
 
   --- NeSet Functor
-  --- Apply Pos/Neg Functor To Sorts
+  --- Apply PosEq/NegEq Functor To Sorts
   subsort PosEqLitNeSet  NegEqLitNeSet  < EqLitNeSet  .
-  subsort PosConjNeSet NegConjNeSet < EqConjNeSet .
-  subsort PosDisjNeSet NegDisjNeSet < EqDisjNeSet .
-  subsort PosFormNeSet NegFormNeSet < EqFormNeSet .
-  --- Apply Pos/Neg Functor To Subsort Arrows
-  subsort PosEqLitNeSet < PosConjNeSet PosDisjNeSet < PosFormNeSet .
-  subsort NegEqLitNeSet < NegConjNeSet NegDisjNeSet < NegFormNeSet .
+  subsort PosEqConjNeSet NegEqConjNeSet < EqConjNeSet .
+  subsort PosEqDisjNeSet NegEqDisjNeSet < EqDisjNeSet .
+  subsort PosEqFormNeSet NegEqFormNeSet < EqFormNeSet .
+  --- Apply PosEq/NegEq Functor To Subsort Arrows
+  subsort PosEqLitNeSet < PosEqConjNeSet PosEqDisjNeSet < PosEqFormNeSet .
+  subsort NegEqLitNeSet < NegEqConjNeSet NegEqDisjNeSet < NegEqFormNeSet .
   subsort EqLitNeSet    < EqConjNeSet    EqDisjNeSet    < EqFormNeSet    .
   --- Other Cases
   subsort EqFormNeSet < NormFormNeSet < FormNeSet .
 
   op mtFormSet :                           -> EmptyFormSet   [ctor] .
-  op (_|_) : EmptyFormSet   EmptyFormSet   -> EmptyFormSet   [ctor assoc comm id: mtFormSet] .
+  op (_|_) : EmptyFormSet    EmptyFormSet  -> EmptyFormSet   [ctor assoc comm id: mtFormSet] .
 
-  op (_|_) : PosEqLitSet    PosEqLitSet    -> PosEqLitSet    [ctor ditto] .
-  op (_|_) : PosConjSet   PosConjSet   -> PosConjSet   [ctor ditto] .
-  op (_|_) : PosDisjSet   PosDisjSet   -> PosDisjSet   [ctor ditto] .
-  op (_|_) : PosFormSet   PosFormSet   -> PosFormSet   [ctor ditto] .
-  op (_|_) : NegEqLitSet    NegEqLitSet    -> NegEqLitSet    [ctor ditto] .
-  op (_|_) : NegConjSet   NegConjSet   -> NegConjSet   [ctor ditto] .
-  op (_|_) : NegDisjSet   NegDisjSet   -> NegDisjSet   [ctor ditto] .
-  op (_|_) : NegFormSet   NegFormSet   -> NegFormSet   [ctor ditto] .
-  op (_|_) : EqLitSet       EqLitSet       -> EqLitSet       [ctor ditto] .
-  op (_|_) : EqConjSet      EqConjSet      -> EqConjSet      [ctor ditto] .
-  op (_|_) : EqDisjSet      EqDisjSet      -> EqDisjSet      [ctor ditto] .
-  op (_|_) : EqFormSet      EqFormSet      -> EqFormSet      [ctor ditto] .
-  op (_|_) : NormFormSet    NormFormSet    -> NormFormSet    [ctor ditto] .
-  op (_|_) : FormSet        FormSet        -> FormSet        [ctor ditto] .
+  op (_|_) : PosEqLitSet     PosEqLitSet   -> PosEqLitSet    [ctor ditto] .
+  op (_|_) : PosEqConjSet    PosEqConjSet  -> PosEqConjSet   [ctor ditto] .
+  op (_|_) : PosEqDisjSet    PosEqDisjSet  -> PosEqDisjSet   [ctor ditto] .
+  op (_|_) : PosEqFormSet    PosEqFormSet  -> PosEqFormSet   [ctor ditto] .
+  op (_|_) : NegEqLitSet     NegEqLitSet   -> NegEqLitSet    [ctor ditto] .
+  op (_|_) : NegEqConjSet    NegEqConjSet  -> NegEqConjSet   [ctor ditto] .
+  op (_|_) : NegEqDisjSet    NegEqDisjSet  -> NegEqDisjSet   [ctor ditto] .
+  op (_|_) : NegEqFormSet    NegEqFormSet  -> NegEqFormSet   [ctor ditto] .
+  op (_|_) : EqLitSet        EqLitSet      -> EqLitSet       [ctor ditto] .
+  op (_|_) : EqConjSet       EqConjSet     -> EqConjSet      [ctor ditto] .
+  op (_|_) : EqDisjSet       EqDisjSet     -> EqDisjSet      [ctor ditto] .
+  op (_|_) : EqFormSet       EqFormSet     -> EqFormSet      [ctor ditto] .
+  op (_|_) : NormFormSet     NormFormSet   -> NormFormSet    [ctor ditto] .
+  op (_|_) : FormSet         FormSet       -> FormSet        [ctor ditto] .
 
-  op (_|_) : PosEqLitNeSet  PosEqLitSet    -> PosEqLitNeSet  [ctor ditto] .
-  op (_|_) : PosConjNeSet PosConjSet   -> PosConjNeSet [ctor ditto] .
-  op (_|_) : PosDisjNeSet PosDisjSet   -> PosDisjNeSet [ctor ditto] .
-  op (_|_) : PosFormNeSet PosFormSet   -> PosFormNeSet [ctor ditto] .
-  op (_|_) : NegEqLitNeSet  NegEqLitSet    -> NegEqLitNeSet  [ctor ditto] .
-  op (_|_) : NegConjNeSet NegConjSet   -> NegConjNeSet [ctor ditto] .
-  op (_|_) : NegDisjNeSet NegDisjSet   -> NegDisjNeSet [ctor ditto] .
-  op (_|_) : NegFormNeSet NegFormSet   -> NegFormNeSet [ctor ditto] .
-  op (_|_) : EqLitNeSet     EqLitSet       -> EqLitNeSet     [ctor ditto] .
-  op (_|_) : EqConjNeSet    EqConjSet      -> EqConjNeSet    [ctor ditto] .
-  op (_|_) : EqDisjNeSet    EqDisjSet      -> EqDisjNeSet    [ctor ditto] .
-  op (_|_) : EqFormNeSet    EqFormSet      -> EqFormNeSet    [ctor ditto] .
-  op (_|_) : NormFormNeSet  NormFormSet    -> NormFormNeSet  [ctor ditto] .
-  op (_|_) : FormNeSet      FormSet        -> FormNeSet      [ctor ditto] .
+  op (_|_) : PosEqLitNeSet   PosEqLitSet   -> PosEqLitNeSet  [ctor ditto] .
+  op (_|_) : PosEqConjNeSet  PosEqConjSet  -> PosEqConjNeSet [ctor ditto] .
+  op (_|_) : PosEqDisjNeSet  PosEqDisjSet  -> PosEqDisjNeSet [ctor ditto] .
+  op (_|_) : PosEqFormNeSet  PosEqFormSet  -> PosEqFormNeSet [ctor ditto] .
+  op (_|_) : NegEqLitNeSet   NegEqLitSet   -> NegEqLitNeSet  [ctor ditto] .
+  op (_|_) : NegEqConjNeSet  NegEqConjSet  -> NegEqConjNeSet [ctor ditto] .
+  op (_|_) : NegEqDisjNeSet  NegEqDisjSet  -> NegEqDisjNeSet [ctor ditto] .
+  op (_|_) : NegEqFormNeSet  NegEqFormSet  -> NegEqFormNeSet [ctor ditto] .
+  op (_|_) : EqLitNeSet      EqLitSet      -> EqLitNeSet     [ctor ditto] .
+  op (_|_) : EqConjNeSet     EqConjSet     -> EqConjNeSet    [ctor ditto] .
+  op (_|_) : EqDisjNeSet     EqDisjSet     -> EqDisjNeSet    [ctor ditto] .
+  op (_|_) : EqFormNeSet     EqFormSet     -> EqFormNeSet    [ctor ditto] .
+  op (_|_) : NormFormNeSet   NormFormSet   -> NormFormNeSet  [ctor ditto] .
+  op (_|_) : FormNeSet       FormSet       -> FormNeSet      [ctor ditto] .
 endfm
 ```

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -166,8 +166,8 @@ fmod EQFORM is
 
   op tt   :           -> TrueLit     [ctor] .
   op ff   :           -> FalseLit    [ctor] .
-  op _?=_ : Term Term -> PosEqLit    [ctor prec 50] .
-  op _!=_ : Term Term -> NegEqLit    [ctor prec 50] .
+  op _?=_ : Term Term -> PosEqLit    [ctor comm prec 50] .
+  op _!=_ : Term Term -> NegEqLit    [ctor comm prec 50] .
   op ~_   : Lit       -> NonTrivLit  [ctor prec 51] .
   op ~_   : Form      -> NonTrivForm [ctor prec 51] .
 

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -110,115 +110,101 @@ load terms.maude
 
 set include BOOL off .
 
-fmod EQFORM is
-  pr META-TERM .
-  pr SUBSTITUTION-SET .
+fmod EQFORM-IMPL{X :: TRIV} is
 
-  sort TrueLit   FalseLit         .
-  sort PosEqLit  NegEqLit  EqLit  .
-  sort PosEqConj NegEqConj EqConj .
-  sort PosEqDisj NegEqDisj EqDisj .
-  sort PosEqForm NegEqForm EqForm .
+  sort TrueLit{X}   FalseLit{X}         .
+  sort PosEqLit{X}  NegEqLit{X}  EqLit{X}  .
+  sort PosEqConj{X} NegEqConj{X} EqConj{X} .
+  sort PosEqDisj{X} NegEqDisj{X} EqDisj{X} .
+  sort PosEqForm{X} NegEqForm{X} EqForm{X} .
 
-  subsort PosEqLit NegEqLit < EqLit .
+  subsort PosEqLit{X} NegEqLit{X} < EqLit{X} .
   ---
-  subsort PosEqLit < PosEqConj PosEqDisj .
-  subsort NegEqLit < NegEqConj NegEqDisj .
-  subsort EqLit    < EqConj    EqDisj    .
+  subsort PosEqLit{X} < PosEqConj{X} PosEqDisj{X} .
+  subsort NegEqLit{X} < NegEqConj{X} NegEqDisj{X} .
+  subsort EqLit{X}    < EqConj{X}    EqDisj{X}    .
   ---
-  subsort PosEqConj NegEqConj < EqConj .
-  subsort PosEqDisj NegEqDisj < EqDisj .
-  subsort PosEqForm NegEqForm < EqForm .
+  subsort PosEqConj{X} NegEqConj{X} < EqConj{X} .
+  subsort PosEqDisj{X} NegEqDisj{X} < EqDisj{X} .
+  subsort PosEqForm{X} NegEqForm{X} < EqForm{X} .
   ---
-  subsort PosEqConj PosEqDisj < PosEqForm .
-  subsort NegEqConj NegEqDisj < NegEqForm .
-  subsort EqConj    EqDisj    < EqForm    .
+  subsort PosEqConj{X} PosEqDisj{X} < PosEqForm{X} .
+  subsort NegEqConj{X} NegEqDisj{X} < NegEqForm{X} .
+  subsort EqConj{X}    EqDisj{X}    < EqForm{X}    .
 
-  sort TrivTrueForm TrivFalseForm NonTrivForm .
-  subsort TrueLit  < TrivTrueForm  .
-  subsort FalseLit < TrivFalseForm .
-  subsort EqForm   < NonTrivForm   .
+  sort TrivTrueForm{X} TrivFalseForm{X} NonTrivForm{X} .
+  subsort TrueLit{X}  < TrivTrueForm{X}  .
+  subsort FalseLit{X} < TrivFalseForm{X} .
+  subsort EqForm{X}   < NonTrivForm{X}   .
 
-  sort NoTrueForm NoFalseForm .
-  subsort NonTrivForm TrivFalseForm < NoTrueForm  .
-  subsort NonTrivForm TrivTrueForm  < NoFalseForm .
+  sort NoTrueForm{X} NoFalseForm{X} .
+  subsort NonTrivForm{X} TrivFalseForm{X} < NoTrueForm{X}  .
+  subsort NonTrivForm{X} TrivTrueForm{X}  < NoFalseForm{X} .
 
-  sort NormLit NormForm .
-  subsort EqLit TrueLit FalseLit < NormLit < NormForm  .
-  subsort EqForm TrivTrueForm TrivFalseForm < NormForm .
+  sort NormLit{X} NormForm{X} .
+  subsort EqLit{X} TrueLit{X} FalseLit{X} < NormLit{X} < NormForm{X}  .
+  subsort EqForm{X} TrivTrueForm{X} TrivFalseForm{X} < NormForm{X} .
 
-  sort Form .
-  subsort NoTrueForm NoFalseForm NormForm < Form .
+  sort Form{X} .
+  subsort NoTrueForm{X} NoFalseForm{X} NormForm{X} < Form{X} .
 
   --- needed for preregularity with if_then_else_fi
-  sort Eq+TrueLit Eq+FalseLit Eq+TrivTrueForm Eq+TrivFalseForm .
-  subsort EqLit  TrueLit       < Eq+TrueLit       < Eq+TrivTrueForm  NormLit  .
-  subsort EqLit  FalseLit      < Eq+FalseLit      < Eq+TrivFalseForm NormLit  .
-  subsort EqForm TrivTrueForm  < Eq+TrivTrueForm  < NoFalseForm      NormForm .
-  subsort EqForm TrivFalseForm < Eq+TrivFalseForm < NoTrueForm       NormForm .
+  sort Eq+TrueLit{X} Eq+FalseLit{X} Eq+TrivTrueForm{X} Eq+TrivFalseForm{X} .
+  subsort EqLit{X}  TrueLit{X}       < Eq+TrueLit{X}       < Eq+TrivTrueForm{X}  NormLit{X}  .
+  subsort EqLit{X}  FalseLit{X}      < Eq+FalseLit{X}      < Eq+TrivFalseForm{X} NormLit{X}  .
+  subsort EqForm{X} TrivTrueForm{X}  < Eq+TrivTrueForm{X}  < NoFalseForm{X}      NormForm{X} .
+  subsort EqForm{X} TrivFalseForm{X} < Eq+TrivFalseForm{X} < NoTrueForm{X}       NormForm{X} .
 
   --- add these subsorts and (op ~_ : Lit -> NonTrivLit) to get proper literals
-  sort NonTrivLit NoFalseLit NoTrueLit Lit .
-  subsort EqLit < NonTrivLit < NonTrivForm .
-  subsort NormLit NoFalseLit NoTrueLit < Lit < Form .
-  subsort NonTrivLit Eq+TrueLit  < NoFalseLit < NoFalseForm .
-  subsort NonTrivLit Eq+FalseLit < NoTrueLit  < NoTrueForm  .
+  sort NonTrivLit{X} NoFalseLit{X} NoTrueLit{X} Lit{X} .
+  subsort EqLit{X} < NonTrivLit{X} < NonTrivForm{X} .
+  subsort NormLit{X} NoFalseLit{X} NoTrueLit{X} < Lit{X} < Form{X} .
+  subsort NonTrivLit{X} Eq+TrueLit{X}  < NoFalseLit{X} < NoFalseForm{X} .
+  subsort NonTrivLit{X} Eq+FalseLit{X} < NoTrueLit{X}  < NoTrueForm{X}  .
 
-  op tt   :           -> TrueLit     [ctor] .
-  op ff   :           -> FalseLit    [ctor] .
-  op _?=_ : Term Term -> PosEqLit    [ctor comm prec 50] .
-  op _!=_ : Term Term -> NegEqLit    [ctor comm prec 50] .
-  op ~_   : Lit       -> NonTrivLit  [ctor prec 51] .
-  op ~_   : Form      -> NonTrivForm [ctor prec 51] .
+  op tt   :             -> TrueLit{X}     [ctor] .
+  op ff   :             -> FalseLit{X}    [ctor] .
+  op _?=_ : X$Elt X$Elt -> PosEqLit{X}    [ctor comm prec 50] .
+  op _!=_ : X$Elt X$Elt -> NegEqLit{X}    [ctor comm prec 50] .
+  op ~_   : Lit{X}      -> NonTrivLit{X}  [ctor prec 51] .
+  op ~_   : Form{X}     -> NonTrivForm{X} [ctor prec 51] .
 
-  op _/\_ : TrivTrueForm   TrivTrueForm   -> TrivTrueForm  [ctor assoc comm id: tt prec 52] .
+  op _/\_ : TrivTrueForm{X}   TrivTrueForm{X}   -> TrivTrueForm{X}  [ctor assoc comm id: tt prec 52] .
   ---
-  op _/\_ : TrivFalseForm  TrivFalseForm  -> TrivFalseForm [ditto] .
-  op _/\_ : TrivTrueForm   TrivFalseForm  -> TrivFalseForm [ditto] .
+  op _/\_ : TrivFalseForm{X}  TrivFalseForm{X}  -> TrivFalseForm{X} [ditto] .
+  op _/\_ : TrivTrueForm{X}   TrivFalseForm{X}  -> TrivFalseForm{X} [ditto] .
   ---
-  op _/\_ : TrivTrueForm   NonTrivForm    -> NonTrivForm   [ditto] .
-  op _/\_ : TrivFalseForm  NonTrivForm    -> NonTrivForm   [ditto] .
+  op _/\_ : TrivTrueForm{X}   NonTrivForm{X}    -> NonTrivForm{X}   [ditto] .
+  op _/\_ : TrivFalseForm{X}  NonTrivForm{X}    -> NonTrivForm{X}   [ditto] .
   ---
-  op _/\_ : PosEqConj      PosEqConj      -> PosEqConj     [ditto] .
-  op _/\_ : NegEqConj      NegEqConj      -> NegEqConj     [ditto] .
-  op _/\_ : EqConj         EqConj         -> EqConj        [ditto] .
-  op _/\_ : PosEqForm      PosEqForm      -> PosEqForm     [ditto] .
-  op _/\_ : NegEqForm      NegEqForm      -> NegEqForm     [ditto] .
-  op _/\_ : EqForm         EqForm         -> EqForm        [ditto] .
-  op _/\_ : NonTrivForm    NonTrivForm    -> NonTrivForm   [ditto] .
-  op _/\_ : Form           Form           -> Form          [ditto] .
+  op _/\_ : PosEqConj{X}      PosEqConj{X}      -> PosEqConj{X}     [ditto] .
+  op _/\_ : NegEqConj{X}      NegEqConj{X}      -> NegEqConj{X}     [ditto] .
+  op _/\_ : EqConj{X}         EqConj{X}         -> EqConj{X}        [ditto] .
+  op _/\_ : PosEqForm{X}      PosEqForm{X}      -> PosEqForm{X}     [ditto] .
+  op _/\_ : NegEqForm{X}      NegEqForm{X}      -> NegEqForm{X}     [ditto] .
+  op _/\_ : EqForm{X}         EqForm{X}         -> EqForm{X}        [ditto] .
+  op _/\_ : NonTrivForm{X}    NonTrivForm{X}    -> NonTrivForm{X}   [ditto] .
+  op _/\_ : Form{X}           Form{X}           -> Form{X}          [ditto] .
 
-  op _\/_ : TrivFalseForm  TrivFalseForm  -> TrivFalseForm [ctor assoc comm id: ff prec 52] .
-  op _\/_ : TrivTrueForm   TrivTrueForm   -> TrivTrueForm  [ditto] .
-  op _\/_ : TrivFalseForm  TrivTrueForm   -> TrivTrueForm  [ditto] .
+  op _\/_ : TrivFalseForm{X}  TrivFalseForm{X}  -> TrivFalseForm{X} [ctor assoc comm id: ff prec 52] .
+  op _\/_ : TrivTrueForm{X}   TrivTrueForm{X}   -> TrivTrueForm{X}  [ditto] .
+  op _\/_ : TrivFalseForm{X}  TrivTrueForm{X}   -> TrivTrueForm{X}  [ditto] .
   ---
-  op _\/_ : TrivFalseForm  NonTrivForm    -> NonTrivForm   [ditto] .
-  op _\/_ : TrivTrueForm   NonTrivForm    -> NonTrivForm   [ditto] .
+  op _\/_ : TrivFalseForm{X}  NonTrivForm{X}    -> NonTrivForm{X}   [ditto] .
+  op _\/_ : TrivTrueForm{X}   NonTrivForm{X}    -> NonTrivForm{X}   [ditto] .
   ---
-  op _\/_ : PosEqDisj      PosEqDisj      -> PosEqDisj     [ditto] .
-  op _\/_ : NegEqDisj      NegEqDisj      -> NegEqDisj     [ditto] .
-  op _\/_ : EqDisj         EqDisj         -> EqDisj        [ditto] .
-  op _\/_ : PosEqForm      PosEqForm      -> PosEqForm     [ditto] .
-  op _\/_ : NegEqForm      NegEqForm      -> NegEqForm     [ditto] .
-  op _\/_ : EqForm         EqForm         -> EqForm        [ditto] .
-  op _\/_ : NonTrivForm    NonTrivForm    -> NonTrivForm   [ditto] .
-  op _\/_ : Form           Form           -> Form          [ditto] .
+  op _\/_ : PosEqDisj{X}      PosEqDisj{X}      -> PosEqDisj{X}     [ditto] .
+  op _\/_ : NegEqDisj{X}      NegEqDisj{X}      -> NegEqDisj{X}     [ditto] .
+  op _\/_ : EqDisj{X}         EqDisj{X}         -> EqDisj{X}        [ditto] .
+  op _\/_ : PosEqForm{X}      PosEqForm{X}      -> PosEqForm{X}     [ditto] .
+  op _\/_ : NegEqForm{X}      NegEqForm{X}      -> NegEqForm{X}     [ditto] .
+  op _\/_ : EqForm{X}         EqForm{X}         -> EqForm{X}        [ditto] .
+  op _\/_ : NonTrivForm{X}    NonTrivForm{X}    -> NonTrivForm{X}   [ditto] .
+  op _\/_ : Form{X}           Form{X}           -> Form{X}          [ditto] .
+  ---------------------------------------------------------------------------
 
-  --- We want: Form = NonTrivForm | TrivTrueForm | TrivFalseForm
-  --- Thus, these are not needed
-  ---
-  --- op _/\_ : TrivTrueForm  Form -> Form [ditto] .
-  --- op _/\_ : TrivFalseForm Form -> Form [ditto] .
-  --- op _\/_ : TrivFalseForm Form -> Form [ditto] .
-  --- op _\/_ : TrivTrueForm  Form -> Form [ditto] .
-  --------------------------------------------------
-
-  var EqL : EqLit .
-  vars F F' : Form .
-  vars CF CG : NoTrueForm .
-  vars DF DG : NoFalseForm .
-  vars T T' : Term .
-  var SUB : Substitution .
+  var EqL : EqLit{X} .
+  vars F F' : Form{X} .
 
   eq ff /\ EqL = ff .
   eq tt \/ EqL = tt .
@@ -227,11 +213,54 @@ fmod EQFORM is
   eq EqL \/ EqL = EqL .
 
   --- Implication
-  op _=>_  : Form Form -> Form .
-  op _<=>_ : Form Form -> Form .
-  ------------------------------
+  op _=>_  : Form{X} Form{X} -> Form{X} .
+  op _<=>_ : Form{X} Form{X} -> Form{X} .
+  ---------------------------------------
   eq F  => F' = (~ F) \/ F' .
   eq F <=> F' = (F => F') /\ (F' => F) .
+endfm
+
+view Term from TRIV to META-TERM is sort Elt to Term . endv
+
+fmod EQFORM is
+  pr SUBSTITUTION-SET .
+  pr EQFORM-IMPL{Term} * (
+    sort TrueLit{Term}          to TrueLit,
+    sort FalseLit{Term}         to FalseLit,
+    sort PosEqLit{Term}         to PosEqLit,
+    sort NegEqLit{Term}         to NegEqLit,
+    sort EqLit{Term}            to EqLit,
+    sort PosEqConj{Term}        to PosEqConj,
+    sort NegEqConj{Term}        to NegEqConj,
+    sort EqConj{Term}           to EqConj,
+    sort PosEqDisj{Term}        to PosEqDisj,
+    sort NegEqDisj{Term}        to NegEqDisj,
+    sort EqDisj{Term}           to EqDisj,
+    sort PosEqForm{Term}        to PosEqForm,
+    sort NegEqForm{Term}        to NegEqForm,
+    sort EqForm{Term}           to EqForm,
+    sort TrivTrueForm{Term}     to TrivTrueForm,
+    sort TrivFalseForm{Term}    to TrivFalseForm,
+    sort NonTrivForm{Term}      to NonTrivForm,
+    sort NoTrueForm{Term}       to NoTrueForm,
+    sort NoFalseForm{Term}      to NoFalseForm,
+    sort NormLit{Term}          to NormLit,
+    sort NormForm{Term}         to NormForm,
+    sort Form{Term}             to Form,
+    sort Eq+TrueLit{Term}       to Eq+TrueLit,
+    sort Eq+FalseLit{Term}      to Eq+FalseLit,
+    sort Eq+TrivTrueForm{Term}  to Eq+TrivTrueForm,
+    sort Eq+TrivFalseForm{Term} to Eq+TrivFalseForm,
+    sort NonTrivLit{Term}       to NonTrivLit,
+    sort NoFalseLit{Term}       to NoFalseLit,
+    sort NoTrueLit{Term}        to NoTrueLit,
+    sort Lit{Term}              to Lit) .
+
+  var F : Form .
+  vars CF CG : NoTrueForm .
+  vars DF DG : NoFalseForm .
+  vars T T' : Term .
+  var SUB : Substitution .
 
   op _<<_ : Form Substitution -> Form .
   -------------------------------------

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -150,6 +150,13 @@ fmod EQFORM is
   sort Form .
   subsort NoTrueForm NoFalseForm NormForm < Form .
 
+  --- needed for preregularity with if_then_else_fi
+  sort Eq+TrueLit Eq+FalseLit Eq+TrivTrueForm Eq+TrivFalseForm .
+  subsort EqLit  TrueLit       < Eq+TrueLit       < Eq+TrivTrueForm  NormLit  .
+  subsort EqLit  FalseLit      < Eq+FalseLit      < Eq+TrivFalseForm NormLit  .
+  subsort EqForm TrivTrueForm  < Eq+TrivTrueForm  < NoFalseForm      NormForm .
+  subsort EqForm TrivFalseForm < Eq+TrivFalseForm < NoTrueForm       NormForm .
+
   op tt   :           -> TrueLit     [ctor] .
   op ff   :           -> FalseLit    [ctor] .
   op _?=_ : Term Term -> PosEqLit    [ctor prec 50] .

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -16,17 +16,15 @@ This library provides formula sorts to cover these core cases and more:
 
 4.  `True`     - the sort of the formula in case [1] above
 5.  `False`    - the sort of the formula in case [2] above
-6.  `TruthLit` - the sort of formulas in cases [1-2] above
-7.  `EqLit`    - positive (`_?=_`) or (`_!=_`) negative equality literals
-8.  `EqForm`   - the sort of formulas in case [3] above
-9.  `NormForm` - the sort containing all formulas in cases [1-3] above
-10. `Form`     - the sort of all quantifier-free equational formulas
+6.  `EqLit`    - positive (`_?=_`) or (`_!=_`) negative equality literals
+7.  `EqForm`   - the sort of formulas in case [3] above
+8.  `NormForm` - the sort containing all formulas in cases [1-3] above
+9.  `Form`     - the sort of all quantifier-free equational formulas
 
 This library also provides other formula sorts that are needed for programming purposes:
 
-11. `NegTruthLit` - (~ ... ~ true) or (~ ... ~ false)
-12. `NoTrueForm`  - Formulas over False + EqLit + NegTruthLit
-13. `NoFalseForm` - Formulas over True + EqLit + NegTruthLit
+10. `NoTrueForm`  - Formulas over ...
+11. `NoFalseForm` - Formulas over ...
 
 Q:  Why are these seemingly weird sorts needed?
 
@@ -96,171 +94,101 @@ load terms.maude
 
 set include BOOL off .
 
-fmod EQFORM-IMPL{X :: TRIV} is
-  pr BOOL .
-  --- Sorts For Formulas Over Equalities
-  sort PosEqLit{X} PosEqConj{X} PosEqDisj{X} PosEqForm{X} .
-  sort NegEqLit{X} NegEqConj{X} NegEqDisj{X} NegEqForm{X} .
-  sort EqLit{X}    EqConj{X}    EqDisj{X}    EqForm{X}    .
-
-  --- Sorts For Formulas Over Everything
-  sort TrueLit{X} FalseLit{X} TruthLit{X} .
-  ---
-  sort NegTruthLit{X}  NoTrueLit{X}  NoFalseLit{X}  NormLit{X}  Lit{X}  .
-  sort NegTruthConj{X} NoTrueConj{X} NoFalseConj{X} NormConj{X} Conj{X} .
-  sort NegTruthDisj{X} NoTrueDisj{X} NoFalseDisj{X} NormDisj{X} Disj{X} .
-  sort NegTruthForm{X} NoTrueForm{X} NoFalseForm{X} NormForm{X} Form{X} .
-
-  --- Subsorts For Formulas Over Equalities
-  --- Apply PosEq/NegEq Functor To Sorts
-  subsort PosEqLit{X}  NegEqLit{X}  < EqLit{X}  .
-  subsort PosEqConj{X} NegEqConj{X} < EqConj{X} .
-  subsort PosEqDisj{X} NegEqDisj{X} < EqDisj{X} .
-  subsort PosEqForm{X} NegEqForm{X} < EqForm{X} .
-
-  --- Apply PosEq/NegEq Functor To Subsort Arrows
-  subsort PosEqLit{X} < PosEqConj{X} PosEqDisj{X} < PosEqForm{X} .
-  subsort NegEqLit{X} < NegEqConj{X} NegEqDisj{X} < NegEqForm{X} .
-  subsort EqLit{X}    < EqConj{X}    EqDisj{X}    < EqForm{X}    .
-
-  --- Subsorts For Formulas Over Everything
-  --- Define Non-Equality Literals
-  subsort TrueLit{X}  FalseLit{X}    < TruthLit{X}   .
-  subsort TrueLit{X}  NegTruthLit{X} < NoFalseLit{X} .
-  subsort FalseLit{X} NegTruthLit{X} < NoTrueLit{X}  .
-  subsort TruthLit{X} NoFalseLit{X}  NoTrueLit{X} < NormLit{X} .
-
-  --- Apply Each Functor To Sorts
-  subsort NegTruthLit{X} < NegTruthConj{X} NegTruthDisj{X} < NegTruthForm{X} .
-  subsort NoTrueLit{X}   < NoTrueConj{X}   NoTrueDisj{X}   < NoTrueForm{X} .
-  subsort NoFalseLit{X}  < NoFalseConj{X}  NoFalseDisj{X}  < NoFalseForm{X} .
-  subsort NormLit{X}     < NormConj{X}     NormDisj{X}     < NormForm{X} .
-  subsort Lit{X}         < Conj{X}         Disj{X}         < Form{X} .
-
-  --- Apply Each Functor To Subsort Arrows
-  subsort EqLit{X}  < NegTruthLit{X}  < NoTrueLit{X}  NoFalseLit{X}  < NormLit{X}  < Lit{X}  .
-  subsort EqConj{X} < NegTruthConj{X} < NoTrueConj{X} NoFalseConj{X} < NormConj{X} < Conj{X} .
-  subsort EqDisj{X} < NegTruthDisj{X} < NoTrueDisj{X} NoFalseDisj{X} < NormDisj{X} < Disj{X} .
-  subsort EqForm{X} < NegTruthForm{X} < NoTrueForm{X} NoFalseForm{X} < NormForm{X} < Form{X} .
-
-  vars F F' : Form{X} . var EqL : EqLit{X} .
-
-  --- Define Literals
-  op tt : -> TrueLit{X} [ctor] .
-  op ff : -> FalseLit{X} [ctor] .
-  op _?=_ : X$Elt X$Elt -> PosEqLit{X} [ctor comm prec 50] .
-  op _!=_ : X$Elt X$Elt -> NegEqLit{X} [ctor comm prec 50] .
-  op ~_ : TruthLit{X} -> NegTruthLit{X} [ctor prec 51] .
-  op ~_ : NegTruthLit{X} -> NegTruthLit{X} [ctor ditto] .
-  op ~_ : Form{X} -> Form{X} [ctor ditto] .
-
-  --- Conjunctions/Disjunctions Over Equalities
-  op _/\_ : PosEqConj{X} PosEqConj{X} -> PosEqConj{X} [ctor assoc comm id: tt prec 52] .
-  op _/\_ : NegEqConj{X} NegEqConj{X} -> NegEqConj{X} [ctor ditto] .
-  op _/\_ : EqConj{X} EqConj{X} -> EqConj{X} [ctor ditto] .
-  ---
-  op _/\_ : PosEqForm{X} PosEqForm{X} -> PosEqForm{X} [ctor ditto] .
-  op _/\_ : NegEqForm{X} NegEqForm{X} -> NegEqForm{X} [ctor ditto] .
-  op _/\_ : EqForm{X} EqForm{X} -> EqForm{X} [ctor ditto] .
-  ---
-  op _\/_ : PosEqDisj{X} PosEqDisj{X} -> PosEqDisj{X} [ctor assoc comm id: ff prec 52] .
-  op _\/_ : NegEqDisj{X} NegEqDisj{X} -> NegEqDisj{X} [ctor ditto] .
-  op _\/_ : EqDisj{X} EqDisj{X} -> EqDisj{X} [ctor ditto] .
-  ---
-  op _\/_ : PosEqForm{X} PosEqForm{X} -> PosEqForm{X} [ctor ditto] .
-  op _\/_ : NegEqForm{X} NegEqForm{X} -> NegEqForm{X} [ctor ditto] .
-  op _\/_ : EqForm{X} EqForm{X} -> EqForm{X} [ctor ditto] .
-
-  --- Conjunctions/Disjunctions Over Everything
-  op _/\_ : NegTruthConj{X} NegTruthConj{X} -> NegTruthConj{X} [ctor ditto] .
-  op _/\_ : NoTrueConj{X} NoTrueConj{X} -> NoTrueConj{X} [ctor ditto] .
-  op _/\_ : NoFalseConj{X} NoFalseConj{X} -> NoFalseConj{X} [ctor ditto] .
-  op _/\_ : Conj{X} Conj{X} -> Conj{X} [ctor ditto] .
-  ---
-  op _/\_ : NegTruthForm{X} NegTruthForm{X} -> NegTruthForm{X} [ctor ditto] .
-  op _/\_ : NoTrueForm{X} NoTrueForm{X} -> NoTrueForm{X} [ctor ditto] .
-  op _/\_ : NoFalseForm{X} NoFalseForm{X} -> NoFalseForm{X} [ctor ditto] .
-  op _/\_ : Form{X} Form{X} -> Form{X} [ctor ditto] .
-  ---
-  op _\/_ : NegTruthDisj{X} NegTruthDisj{X} -> NegTruthDisj{X} [ctor ditto] .
-  op _\/_ : NoTrueDisj{X} NoTrueDisj{X} -> NoTrueDisj{X} [ctor ditto] .
-  op _\/_ : NoFalseDisj{X} NoFalseDisj{X} -> NoFalseDisj{X} [ctor ditto] .
-  op _\/_ : Disj{X} Disj{X} -> Disj{X} [ctor ditto] .
-  ---
-  op _\/_ : NegTruthForm{X} NegTruthForm{X} -> NegTruthForm{X} [ctor ditto] .
-  op _\/_ : NoTrueForm{X} NoTrueForm{X} -> NoTrueForm{X} [ctor ditto] .
-  op _\/_ : NoFalseForm{X} NoFalseForm{X} -> NoFalseForm{X} [ctor ditto] .
-  op _\/_ : Form{X} Form{X} -> Form{X} [ctor ditto] .
-  ---------------------------------------------------
-  eq ff /\ EqL = ff .
-  eq tt \/ EqL = tt .
-
-  eq EqL /\ EqL = EqL .
-  eq EqL \/ EqL = EqL .
-
-  --- Implication
-  op _=>_  : Form{X} Form{X} -> Form{X} .
-  op _<=>_ : Form{X} Form{X} -> Form{X} .
-  ---------------------------------------
-  eq F  => F' = (~ F) \/ F' .
-  eq F <=> F' = (F => F') /\ (F' => F) .
-endfm
-
-view Term from TRIV to META-TERM is sort Elt to Term . endv
-
 fmod EQFORM is
-   pr SUBSTITUTION-SET .
-   pr EQFORM-IMPL{Term} * (
-      --- Map Formulas Over Equalities
-      sort PosEqLit{Term} to PosEqLit,
-      sort NegEqLit{Term} to NegEqLit,
-      sort EqLit{Term} to EqLit,
-      ---
-      sort PosEqConj{Term} to PosEqConj,
-      sort NegEqConj{Term} to NegEqConj,
-      sort EqConj{Term} to EqConj,
-      ---
-      sort PosEqDisj{Term} to PosEqDisj,
-      sort NegEqDisj{Term} to NegEqDisj,
-      sort EqDisj{Term} to EqDisj,
-      ---
-      sort PosEqForm{Term} to PosEqForm,
-      sort NegEqForm{Term} to NegEqForm,
-      sort EqForm{Term} to EqForm,
+  pr META-TERM .
+  pr SUBSTITUTION-SET .
 
-      --- Map Formulas Over Everything
-      sort TrueLit{Term} to TrueLit,
-      sort FalseLit{Term} to FalseLit,
-      sort TruthLit{Term} to TruthLit,
-      ---
-      sort NegTruthLit{Term} to NegTruthLit,
-      sort NoTrueLit{Term} to NoTrueLit,
-      sort NoFalseLit{Term} to NoFalseLit,
-      sort NormLit{Term} to NormLit,
-      sort Lit{Term} to Lit,
-      ---
-      sort NegTruthConj{Term} to NegTruthConj,
-      sort NoTrueConj{Term} to NoTrueConj,
-      sort NoFalseConj{Term} to NoFalseConj,
-      sort NormConj{Term} to NormConj,
-      sort Conj{Term} to Conj,
-      ---
-      sort NegTruthDisj{Term} to NegTruthDisj,
-      sort NoTrueDisj{Term} to NoTrueDisj,
-      sort NoFalseDisj{Term} to NoFalseDisj,
-      sort NormDisj{Term} to NormDisj,
-      sort Disj{Term} to Disj,
-      ---
-      sort NegTruthForm{Term} to NegTruthForm,
-      sort NoTrueForm{Term} to NoTrueForm,
-      sort NoFalseForm{Term} to NoFalseForm,
-      sort NormForm{Term} to NormForm,
-      sort Form{Term} to Form) .
+  sort TrueLit  FalseLit        .
+  sort PosEqLit NegEqLit EqLit  .
+  sort PosConj  NegConj  EqConj .
+  sort PosDisj  NegDisj  EqDisj .
+  sort PosForm  NegForm  EqForm .
 
-  vars T T' : Term . vars F F' : Form . var SUB : Substitution .
+  subsort PosEqLit NegEqLit < EqLit .
+  ---
+  subsort PosEqLit < PosConj PosDisj .
+  subsort NegEqLit < NegConj NegDisj .
+  subsort EqLit    < EqConj  EqDisj  .
+  ---
+  subsort PosConj NegConj < EqConj .
+  subsort PosDisj NegDisj < EqDisj .
+  subsort PosForm NegForm < EqForm .
+  ---
+  subsort PosConj PosDisj < PosForm .
+  subsort NegConj NegDisj < NegForm .
+  subsort EqConj  EqDisj  < EqForm  .
 
-  op _<<_ : Form Substitution -> [Form] .
-  ---------------------------------------
+  sort TrivTrueForm TrivFalseForm NonTrivForm .
+  subsort TrueLit  < TrivTrueForm  .
+  subsort FalseLit < TrivFalseForm .
+  subsort EqForm   < NonTrivForm   .
+
+  sort NoTrueForm NoFalseForm .
+  subsort NonTrivForm TrivFalseForm < NoTrueForm  .
+  subsort NonTrivForm TrivTrueForm  < NoFalseForm .
+
+  sort NormLit NormForm .
+  subsort EqLit TrueLit FalseLit < NormLit < NormForm  .
+  subsort EqForm TrivTrueForm TrivFalseForm < NormForm .
+
+  sort Form .
+  subsort NoTrueForm NoFalseForm NormForm < Form .
+
+  op tt   :           -> TrueLit     [ctor] .
+  op ff   :           -> FalseLit    [ctor] .
+  op _?=_ : Term Term -> PosEqLit    [ctor prec 50] .
+  op _!=_ : Term Term -> NegEqLit    [ctor prec 50] .
+  op ~_   : Form      -> NonTrivForm [ctor prec 51] .
+
+  op _/\_ : TrivTrueForm   TrivTrueForm   -> TrivTrueForm  [ctor assoc comm id: tt prec 52] .
+  ---
+  op _/\_ : TrivFalseForm  TrivFalseForm  -> TrivFalseForm [ditto] .
+  op _/\_ : TrivTrueForm   TrivFalseForm  -> TrivFalseForm [ditto] .
+  ---
+  op _/\_ : TrivTrueForm   NonTrivForm    -> NonTrivForm   [ditto] .
+  op _/\_ : TrivFalseForm  NonTrivForm    -> NonTrivForm   [ditto] .
+  ---
+  op _/\_ : PosConj        PosConj        -> PosConj       [ditto] .
+  op _/\_ : NegConj        NegConj        -> NegConj       [ditto] .
+  op _/\_ : EqConj         EqConj         -> EqConj        [ditto] .
+  op _/\_ : PosForm        PosForm        -> PosForm       [ditto] .
+  op _/\_ : NegForm        NegForm        -> NegForm       [ditto] .
+  op _/\_ : EqForm         EqForm         -> EqForm        [ditto] .
+  op _/\_ : NonTrivForm    NonTrivForm    -> NonTrivForm   [ditto] .
+  op _/\_ : Form           Form           -> Form          [ditto] .
+
+  op _\/_ : TrivFalseForm  TrivFalseForm  -> TrivFalseForm [ctor assoc comm id: ff prec 52] .
+  op _\/_ : TrivTrueForm   TrivTrueForm   -> TrivTrueForm  [ditto] .
+  op _\/_ : TrivFalseForm  TrivTrueForm   -> TrivTrueForm  [ditto] .
+  ---
+  op _\/_ : TrivFalseForm  NonTrivForm    -> NonTrivForm   [ditto] .
+  op _\/_ : TrivTrueForm   NonTrivForm    -> NonTrivForm   [ditto] .
+  ---
+  op _\/_ : PosDisj        PosDisj        -> PosDisj       [ditto] .
+  op _\/_ : NegDisj        NegDisj        -> NegDisj       [ditto] .
+  op _\/_ : EqDisj         EqDisj         -> EqDisj        [ditto] .
+  op _\/_ : PosForm        PosForm        -> PosForm       [ditto] .
+  op _\/_ : NegForm        NegForm        -> NegForm       [ditto] .
+  op _\/_ : EqForm         EqForm         -> EqForm        [ditto] .
+  op _\/_ : NonTrivForm    NonTrivForm    -> NonTrivForm   [ditto] .
+  op _\/_ : Form           Form           -> Form          [ditto] .
+
+  --- We want: Form = NonTrivForm | TrivTrueForm | TrivFalseForm
+  --- Thus, these are not needed
+  ---
+  --- op _/\_ : TrivTrueForm  Form -> Form [ditto] .
+  --- op _/\_ : TrivFalseForm Form -> Form [ditto] .
+  --- op _\/_ : TrivFalseForm Form -> Form [ditto] .
+  --- op _\/_ : TrivTrueForm  Form -> Form [ditto] .
+
+  var F : Form .
+  vars CF CG : NoTrueForm .
+  vars DF DG : NoFalseForm .
+  vars T T' : Term .
+  var SUB : Substitution .
+
+  op _<<_ : Form Substitution -> Form .
+  -------------------------------------
   eq tt << SUB = tt .
   eq ff << SUB = ff .
 
@@ -269,13 +197,13 @@ fmod EQFORM is
 
   eq (~ F) << SUB = ~ (F << SUB) .
 
- ceq (F /\ F') << SUB = (F << SUB) /\ (F' << SUB) if F =/= tt /\ F' =/= tt .
- ceq (F \/ F') << SUB = (F << SUB) \/ (F' << SUB) if F =/= ff /\ F' =/= ff .
+  eq (CF /\ CG) << SUB = (CF << SUB) /\ (CG << SUB) .
+  eq (DF \/ DG) << SUB = (DF << SUB) \/ (DG << SUB) .
 endfm
 
 fmod EQFORM-NNF is
   pr EQFORM .
-  var F G : Form .
+  var F : Form .
   var CF CG : NoTrueForm .
   var DF DG : NoFalseForm .
   var NL : NormLit .
@@ -283,10 +211,10 @@ fmod EQFORM-NNF is
 
   op nnf : Form -> [Form] .
 
- ceq nnf(F /\ G) = nnf(F) /\ nnf(G) if F =/= tt /\ G =/= tt .
- ceq nnf(F \/ G) = nnf(F) \/ nnf(G) if F =/= ff /\ G =/= ff .
- ceq nnf(~ (F /\ G)) = nnf(~ F) \/ nnf(~ G) if F =/= tt /\ G =/= tt .
- ceq nnf(~ (F \/ G)) = nnf(~ F) /\ nnf(~ G) if F =/= ff /\ G =/= ff .
+  eq nnf(CF /\ CG) = nnf(CF) /\ nnf(CG) .
+  eq nnf(DF \/ DG) = nnf(DF) \/ nnf(DG) .
+  eq nnf(~ (CF /\ CG)) = nnf(~ CF) \/ nnf(~ CG) .
+  eq nnf(~ (DF \/ DG)) = nnf(~ DF) /\ nnf(~ DG) .
   eq nnf(~ ~ F) = nnf(F) .
   eq nnf(~ tt) = ff .
   eq nnf(~ ff) = tt .
@@ -299,9 +227,9 @@ endfm
 ---       Removes all negation and unneeded true/false
 fmod EQFORM-NEF is
   pr EQFORM-NNF .
-  var F G : Form .
+  var F  : Form .
   var NF : NormForm .
-  var EF : EqForm .
+  var VF : NonTrivForm .
   var CF : NoTrueForm .
   var DF : NoFalseForm .
 
@@ -310,10 +238,10 @@ fmod EQFORM-NEF is
 
   eq nef(F) = nef1(nnf(F)) .
   eq nef1(NF) = NF .
- ceq nef1(ff /\ F) = ff if F =/= tt .
- ceq nef1(tt \/ F) = tt if F =/= ff .
- ceq nef1(F /\ G) = nef1(F /\ nef1(G)) if F =/= tt /\ G =/= tt [owise] .
- ceq nef1(F \/ G) = nef1(F \/ nef1(G)) if F =/= ff /\ G =/= ff [owise] .
+  eq nef1(ff /\ CF) = ff .
+  eq nef1(tt \/ DF) = tt .
+  eq nef1(VF /\ CF) = nef1(nef1(VF) /\ nef1(CF)) .
+  eq nef1(VF \/ DF) = nef1(nef1(VF) \/ nef1(DF)) .
 endfm
 
 fth FUN is inc TRIV .
@@ -331,30 +259,28 @@ endfm
 
 fmod EQFORM-CNF-IMPL is
   pr EQFORM-NEF .
-  var F G H : Form .
   var EF EG EH : EqForm .
   var NL : NormLit .
 
   op cnf-impl1 : NormForm -> [NormForm] .
 
   eq cnf-impl1(NL) = NL .
- ceq cnf-impl1((F /\ G) \/ H) = cnf-impl1((F \/ H) /\ (G \/ H)) if F =/= tt /\ G =/= tt /\ H =/= ff .
- ceq cnf-impl1(F \/ G) = cnf-impl1(F) \/ cnf-impl1(G) if F =/= ff /\ G =/= ff [owise] .
- ceq cnf-impl1(F /\ G) = cnf-impl1(F) /\ cnf-impl1(G) if F =/= tt /\ G =/= tt .
+  eq cnf-impl1((EF /\ EG) \/ EH) = cnf-impl1((EF \/ EH) /\ (EG \/ EH)) .
+  eq cnf-impl1(EF \/ EG) = cnf-impl1(EF) \/ cnf-impl1(EG) [owise] .
+  eq cnf-impl1(EF /\ EG) = cnf-impl1(EF) /\ cnf-impl1(EG) .
 endfm
 
 fmod EQFORM-DNF-IMPL is
   pr EQFORM-NEF .
-  var F G H : Form .
   var EF EG EH : EqForm .
   var NL : NormLit .
 
   op dnf-impl1 : NormForm -> [NormForm] .
 
-  eq dnf-impl1(NL) = NL .
- ceq dnf-impl1((F \/ G) /\ H) = dnf-impl1((F /\ H) \/ (G /\ H)) if F =/= ff /\ G =/= ff /\ H =/= tt .
- ceq dnf-impl1(F /\ G) = dnf-impl1(F) /\ dnf-impl1(G) if F =/= tt /\ G =/= tt [owise] .
- ceq dnf-impl1(F \/ G) = dnf-impl1(F) \/ dnf-impl1(G) if F =/= ff /\ G =/= ff .
+ eq dnf-impl1(NL) = NL .
+ eq dnf-impl1((EF \/ EG) /\ EH) = dnf-impl1((EF /\ EH) \/ (EG /\ EH)) .
+ eq dnf-impl1(EF /\ EG) = dnf-impl1(EF) /\ dnf-impl1(EG) [owise] .
+ eq dnf-impl1(EF \/ EG) = dnf-impl1(EF) \/ dnf-impl1(EG) .
 endfm
 
 view cnf from FUN to EQFORM-CNF-IMPL is sort Elt to NormForm . op F to cnf-impl1 . endv
@@ -376,24 +302,24 @@ fmod EQFORM-LIST is
   pr EQFORM .
 
   sort EmptyFormList .
-  sort PosEqLitList PosEqConjList PosEqDisjList PosEqFormList .
-  sort NegEqLitList NegEqConjList NegEqDisjList NegEqFormList .
+  sort PosEqLitList PosConjList PosDisjList PosFormList .
+  sort NegEqLitList NegConjList NegDisjList NegFormList .
   sort EqLitList    EqConjList    EqDisjList    EqFormList    .
   sort NormFormList FormList .
 
-  sort PosEqLitNeList PosEqConjNeList PosEqDisjNeList PosEqFormNeList .
-  sort NegEqLitNeList NegEqConjNeList NegEqDisjNeList NegEqFormNeList .
+  sort PosEqLitNeList PosConjNeList PosDisjNeList PosFormNeList .
+  sort NegEqLitNeList NegConjNeList NegDisjNeList NegFormNeList .
   sort EqLitNeList    EqConjNeList    EqDisjNeList    EqFormNeList    .
   sort NormFormNeList FormNeList .
 
   subsort PosEqLit  < PosEqLitNeList  < PosEqLitList  .
-  subsort PosEqConj < PosEqConjNeList < PosEqConjList .
-  subsort PosEqDisj < PosEqDisjNeList < PosEqDisjList .
-  subsort PosEqForm < PosEqFormNeList < PosEqFormList .
+  subsort PosConj < PosConjNeList < PosConjList .
+  subsort PosDisj < PosDisjNeList < PosDisjList .
+  subsort PosForm < PosFormNeList < PosFormList .
   subsort NegEqLit  < NegEqLitNeList  < NegEqLitList  .
-  subsort NegEqConj < NegEqConjNeList < NegEqConjList .
-  subsort NegEqDisj < NegEqDisjNeList < NegEqDisjList .
-  subsort NegEqForm < NegEqFormNeList < NegEqFormList .
+  subsort NegConj < NegConjNeList < NegConjList .
+  subsort NegDisj < NegDisjNeList < NegDisjList .
+  subsort NegForm < NegFormNeList < NegFormList .
   subsort EqLit     < EqLitNeList     < EqLitList     .
   subsort EqConj    < EqConjNeList    < EqConjList    .
   subsort EqDisj    < EqDisjNeList    < EqDisjList    .
@@ -402,28 +328,28 @@ fmod EQFORM-LIST is
   subsort Form      < FormNeList      < FormList      .
 
   --- List Functor
-  --- Apply PosEq/NegEq Functor To Sorts
+  --- Apply Pos/Neg Functor To Sorts
   subsort PosEqLitList  NegEqLitList  < EqLitList  .
-  subsort PosEqConjList NegEqConjList < EqConjList .
-  subsort PosEqDisjList NegEqDisjList < EqDisjList .
-  subsort PosEqFormList NegEqFormList < EqFormList .
-  --- Apply PosEq/NegEq Functor To Subsort Arrows
-  subsort PosEqLitList < PosEqConjList PosEqDisjList < PosEqFormList .
-  subsort NegEqLitList < NegEqConjList NegEqDisjList < NegEqFormList .
+  subsort PosConjList NegConjList < EqConjList .
+  subsort PosDisjList NegDisjList < EqDisjList .
+  subsort PosFormList NegFormList < EqFormList .
+  --- Apply Pos/Neg Functor To Subsort Arrows
+  subsort PosEqLitList < PosConjList PosDisjList < PosFormList .
+  subsort NegEqLitList < NegConjList NegDisjList < NegFormList .
   subsort EqLitList    < EqConjList    EqDisjList    < EqFormList    .
   --- Other Cases
   subsort EmptyFormList < PosEqLitList NegEqLitList FormList .
   subsort EqFormList < NormFormList < FormList .
 
   --- NeList Functor
-  --- Apply PosEq/NegEq Functor To Sorts
+  --- Apply Pos/Neg Functor To Sorts
   subsort PosEqLitNeList  NegEqLitNeList  < EqLitNeList  .
-  subsort PosEqConjNeList NegEqConjNeList < EqConjNeList .
-  subsort PosEqDisjNeList NegEqDisjNeList < EqDisjNeList .
-  subsort PosEqFormNeList NegEqFormNeList < EqFormNeList .
-  --- Apply PosEq/NegEq Functor To Subsort Arrows
-  subsort PosEqLitNeList < PosEqConjNeList PosEqDisjNeList < PosEqFormNeList .
-  subsort NegEqLitNeList < NegEqConjNeList NegEqDisjNeList < NegEqFormNeList .
+  subsort PosConjNeList NegConjNeList < EqConjNeList .
+  subsort PosDisjNeList NegDisjNeList < EqDisjNeList .
+  subsort PosFormNeList NegFormNeList < EqFormNeList .
+  --- Apply Pos/Neg Functor To Subsort Arrows
+  subsort PosEqLitNeList < PosConjNeList PosDisjNeList < PosFormNeList .
+  subsort NegEqLitNeList < NegConjNeList NegDisjNeList < NegFormNeList .
   subsort EqLitNeList    < EqConjNeList    EqDisjNeList    < EqFormNeList    .
   --- Other Cases
   subsort EqFormNeList < NormFormNeList < FormNeList .
@@ -432,13 +358,13 @@ fmod EQFORM-LIST is
   op (_;_) : EmptyFormList   EmptyFormList   -> EmptyFormList   [ctor assoc id: mtFormList] .
 
   op (_;_) : PosEqLitList    PosEqLitList    -> PosEqLitList    [ctor ditto] .
-  op (_;_) : PosEqConjList   PosEqConjList   -> PosEqConjList   [ctor ditto] .
-  op (_;_) : PosEqDisjList   PosEqDisjList   -> PosEqDisjList   [ctor ditto] .
-  op (_;_) : PosEqFormList   PosEqFormList   -> PosEqFormList   [ctor ditto] .
+  op (_;_) : PosConjList   PosConjList   -> PosConjList   [ctor ditto] .
+  op (_;_) : PosDisjList   PosDisjList   -> PosDisjList   [ctor ditto] .
+  op (_;_) : PosFormList   PosFormList   -> PosFormList   [ctor ditto] .
   op (_;_) : NegEqLitList    NegEqLitList    -> NegEqLitList    [ctor ditto] .
-  op (_;_) : NegEqConjList   NegEqConjList   -> NegEqConjList   [ctor ditto] .
-  op (_;_) : NegEqDisjList   NegEqDisjList   -> NegEqDisjList   [ctor ditto] .
-  op (_;_) : NegEqFormList   NegEqFormList   -> NegEqFormList   [ctor ditto] .
+  op (_;_) : NegConjList   NegConjList   -> NegConjList   [ctor ditto] .
+  op (_;_) : NegDisjList   NegDisjList   -> NegDisjList   [ctor ditto] .
+  op (_;_) : NegFormList   NegFormList   -> NegFormList   [ctor ditto] .
   op (_;_) : EqLitList       EqLitList       -> EqLitList       [ctor ditto] .
   op (_;_) : EqConjList      EqConjList      -> EqConjList      [ctor ditto] .
   op (_;_) : EqDisjList      EqDisjList      -> EqDisjList      [ctor ditto] .
@@ -447,13 +373,13 @@ fmod EQFORM-LIST is
   op (_;_) : FormList        FormList        -> FormList        [ctor ditto] .
 
   op (_;_) : PosEqLitNeList  PosEqLitList    -> PosEqLitNeList  [ctor ditto] .
-  op (_;_) : PosEqConjNeList PosEqConjList   -> PosEqConjNeList [ctor ditto] .
-  op (_;_) : PosEqDisjNeList PosEqDisjList   -> PosEqDisjNeList [ctor ditto] .
-  op (_;_) : PosEqFormNeList PosEqFormList   -> PosEqFormNeList [ctor ditto] .
+  op (_;_) : PosConjNeList PosConjList   -> PosConjNeList [ctor ditto] .
+  op (_;_) : PosDisjNeList PosDisjList   -> PosDisjNeList [ctor ditto] .
+  op (_;_) : PosFormNeList PosFormList   -> PosFormNeList [ctor ditto] .
   op (_;_) : NegEqLitNeList  NegEqLitList    -> NegEqLitNeList  [ctor ditto] .
-  op (_;_) : NegEqConjNeList NegEqConjList   -> NegEqConjNeList [ctor ditto] .
-  op (_;_) : NegEqDisjNeList NegEqDisjList   -> NegEqDisjNeList [ctor ditto] .
-  op (_;_) : NegEqFormNeList NegEqFormList   -> NegEqFormNeList [ctor ditto] .
+  op (_;_) : NegConjNeList NegConjList   -> NegConjNeList [ctor ditto] .
+  op (_;_) : NegDisjNeList NegDisjList   -> NegDisjNeList [ctor ditto] .
+  op (_;_) : NegFormNeList NegFormList   -> NegFormNeList [ctor ditto] .
   op (_;_) : EqLitNeList     EqLitList       -> EqLitNeList     [ctor ditto] .
   op (_;_) : EqConjNeList    EqConjList      -> EqConjNeList    [ctor ditto] .
   op (_;_) : EqDisjNeList    EqDisjList      -> EqDisjNeList    [ctor ditto] .
@@ -462,13 +388,13 @@ fmod EQFORM-LIST is
   op (_;_) : FormNeList      FormList        -> FormNeList      [ctor ditto] .
 
   op (_;_) : PosEqLitList    PosEqLitNeList  -> PosEqLitNeList  [ctor ditto] .
-  op (_;_) : PosEqConjList   PosEqConjNeList -> PosEqConjNeList [ctor ditto] .
-  op (_;_) : PosEqDisjList   PosEqDisjNeList -> PosEqDisjNeList [ctor ditto] .
-  op (_;_) : PosEqFormList   PosEqFormNeList -> PosEqFormNeList [ctor ditto] .
+  op (_;_) : PosConjList   PosConjNeList -> PosConjNeList [ctor ditto] .
+  op (_;_) : PosDisjList   PosDisjNeList -> PosDisjNeList [ctor ditto] .
+  op (_;_) : PosFormList   PosFormNeList -> PosFormNeList [ctor ditto] .
   op (_;_) : NegEqLitList    NegEqLitNeList  -> NegEqLitNeList  [ctor ditto] .
-  op (_;_) : NegEqConjList   NegEqConjNeList -> NegEqConjNeList [ctor ditto] .
-  op (_;_) : NegEqDisjList   NegEqDisjNeList -> NegEqDisjNeList [ctor ditto] .
-  op (_;_) : NegEqFormList   NegEqFormNeList -> NegEqFormNeList [ctor ditto] .
+  op (_;_) : NegConjList   NegConjNeList -> NegConjNeList [ctor ditto] .
+  op (_;_) : NegDisjList   NegDisjNeList -> NegDisjNeList [ctor ditto] .
+  op (_;_) : NegFormList   NegFormNeList -> NegFormNeList [ctor ditto] .
   op (_;_) : EqLitList       EqLitNeList     -> EqLitNeList     [ctor ditto] .
   op (_;_) : EqConjList      EqConjNeList    -> EqConjNeList    [ctor ditto] .
   op (_;_) : EqDisjList      EqDisjNeList    -> EqDisjNeList    [ctor ditto] .
@@ -481,24 +407,24 @@ fmod EQFORM-SET is
   pr EQFORM .
 
   sort EmptyFormSet .
-  sort PosEqLitSet PosEqConjSet PosEqDisjSet PosEqFormSet .
-  sort NegEqLitSet NegEqConjSet NegEqDisjSet NegEqFormSet .
+  sort PosEqLitSet PosConjSet PosDisjSet PosFormSet .
+  sort NegEqLitSet NegConjSet NegDisjSet NegFormSet .
   sort EqLitSet    EqConjSet    EqDisjSet    EqFormSet    .
   sort NormFormSet FormSet .
 
-  sort PosEqLitNeSet PosEqConjNeSet PosEqDisjNeSet PosEqFormNeSet .
-  sort NegEqLitNeSet NegEqConjNeSet NegEqDisjNeSet NegEqFormNeSet .
+  sort PosEqLitNeSet PosConjNeSet PosDisjNeSet PosFormNeSet .
+  sort NegEqLitNeSet NegConjNeSet NegDisjNeSet NegFormNeSet .
   sort EqLitNeSet    EqConjNeSet    EqDisjNeSet    EqFormNeSet    .
   sort NormFormNeSet FormNeSet .
 
   subsort PosEqLit  < PosEqLitNeSet  < PosEqLitSet  .
-  subsort PosEqConj < PosEqConjNeSet < PosEqConjSet .
-  subsort PosEqDisj < PosEqDisjNeSet < PosEqDisjSet .
-  subsort PosEqForm < PosEqFormNeSet < PosEqFormSet .
+  subsort PosConj < PosConjNeSet < PosConjSet .
+  subsort PosDisj < PosDisjNeSet < PosDisjSet .
+  subsort PosForm < PosFormNeSet < PosFormSet .
   subsort NegEqLit  < NegEqLitNeSet  < NegEqLitSet  .
-  subsort NegEqConj < NegEqConjNeSet < NegEqConjSet .
-  subsort NegEqDisj < NegEqDisjNeSet < NegEqDisjSet .
-  subsort NegEqForm < NegEqFormNeSet < NegEqFormSet .
+  subsort NegConj < NegConjNeSet < NegConjSet .
+  subsort NegDisj < NegDisjNeSet < NegDisjSet .
+  subsort NegForm < NegFormNeSet < NegFormSet .
   subsort EqLit     < EqLitNeSet     < EqLitSet     .
   subsort EqConj    < EqConjNeSet    < EqConjSet    .
   subsort EqDisj    < EqDisjNeSet    < EqDisjSet    .
@@ -507,28 +433,28 @@ fmod EQFORM-SET is
   subsort Form      < FormNeSet      < FormSet      .
 
   --- Set Functor
-  --- Apply PosEq/NegEq Functor To Sorts
+  --- Apply Pos/Neg Functor To Sorts
   subsort PosEqLitSet  NegEqLitSet  < EqLitSet  .
-  subsort PosEqConjSet NegEqConjSet < EqConjSet .
-  subsort PosEqDisjSet NegEqDisjSet < EqDisjSet .
-  subsort PosEqFormSet NegEqFormSet < EqFormSet .
-  --- Apply PosEq/NegEq Functor To Subsort Arrows
-  subsort PosEqLitSet < PosEqConjSet PosEqDisjSet < PosEqFormSet .
-  subsort NegEqLitSet < NegEqConjSet NegEqDisjSet < NegEqFormSet .
+  subsort PosConjSet NegConjSet < EqConjSet .
+  subsort PosDisjSet NegDisjSet < EqDisjSet .
+  subsort PosFormSet NegFormSet < EqFormSet .
+  --- Apply Pos/Neg Functor To Subsort Arrows
+  subsort PosEqLitSet < PosConjSet PosDisjSet < PosFormSet .
+  subsort NegEqLitSet < NegConjSet NegDisjSet < NegFormSet .
   subsort EqLitSet    < EqConjSet    EqDisjSet    < EqFormSet    .
   --- Other Cases
   subsort EmptyFormSet < PosEqLitSet NegEqLitSet FormSet .
   subsort EqFormSet < NormFormSet < FormSet .
 
   --- NeSet Functor
-  --- Apply PosEq/NegEq Functor To Sorts
+  --- Apply Pos/Neg Functor To Sorts
   subsort PosEqLitNeSet  NegEqLitNeSet  < EqLitNeSet  .
-  subsort PosEqConjNeSet NegEqConjNeSet < EqConjNeSet .
-  subsort PosEqDisjNeSet NegEqDisjNeSet < EqDisjNeSet .
-  subsort PosEqFormNeSet NegEqFormNeSet < EqFormNeSet .
-  --- Apply PosEq/NegEq Functor To Subsort Arrows
-  subsort PosEqLitNeSet < PosEqConjNeSet PosEqDisjNeSet < PosEqFormNeSet .
-  subsort NegEqLitNeSet < NegEqConjNeSet NegEqDisjNeSet < NegEqFormNeSet .
+  subsort PosConjNeSet NegConjNeSet < EqConjNeSet .
+  subsort PosDisjNeSet NegDisjNeSet < EqDisjNeSet .
+  subsort PosFormNeSet NegFormNeSet < EqFormNeSet .
+  --- Apply Pos/Neg Functor To Subsort Arrows
+  subsort PosEqLitNeSet < PosConjNeSet PosDisjNeSet < PosFormNeSet .
+  subsort NegEqLitNeSet < NegConjNeSet NegDisjNeSet < NegFormNeSet .
   subsort EqLitNeSet    < EqConjNeSet    EqDisjNeSet    < EqFormNeSet    .
   --- Other Cases
   subsort EqFormNeSet < NormFormNeSet < FormNeSet .
@@ -537,13 +463,13 @@ fmod EQFORM-SET is
   op (_|_) : EmptyFormSet   EmptyFormSet   -> EmptyFormSet   [ctor assoc comm id: mtFormSet] .
 
   op (_|_) : PosEqLitSet    PosEqLitSet    -> PosEqLitSet    [ctor ditto] .
-  op (_|_) : PosEqConjSet   PosEqConjSet   -> PosEqConjSet   [ctor ditto] .
-  op (_|_) : PosEqDisjSet   PosEqDisjSet   -> PosEqDisjSet   [ctor ditto] .
-  op (_|_) : PosEqFormSet   PosEqFormSet   -> PosEqFormSet   [ctor ditto] .
+  op (_|_) : PosConjSet   PosConjSet   -> PosConjSet   [ctor ditto] .
+  op (_|_) : PosDisjSet   PosDisjSet   -> PosDisjSet   [ctor ditto] .
+  op (_|_) : PosFormSet   PosFormSet   -> PosFormSet   [ctor ditto] .
   op (_|_) : NegEqLitSet    NegEqLitSet    -> NegEqLitSet    [ctor ditto] .
-  op (_|_) : NegEqConjSet   NegEqConjSet   -> NegEqConjSet   [ctor ditto] .
-  op (_|_) : NegEqDisjSet   NegEqDisjSet   -> NegEqDisjSet   [ctor ditto] .
-  op (_|_) : NegEqFormSet   NegEqFormSet   -> NegEqFormSet   [ctor ditto] .
+  op (_|_) : NegConjSet   NegConjSet   -> NegConjSet   [ctor ditto] .
+  op (_|_) : NegDisjSet   NegDisjSet   -> NegDisjSet   [ctor ditto] .
+  op (_|_) : NegFormSet   NegFormSet   -> NegFormSet   [ctor ditto] .
   op (_|_) : EqLitSet       EqLitSet       -> EqLitSet       [ctor ditto] .
   op (_|_) : EqConjSet      EqConjSet      -> EqConjSet      [ctor ditto] .
   op (_|_) : EqDisjSet      EqDisjSet      -> EqDisjSet      [ctor ditto] .
@@ -552,13 +478,13 @@ fmod EQFORM-SET is
   op (_|_) : FormSet        FormSet        -> FormSet        [ctor ditto] .
 
   op (_|_) : PosEqLitNeSet  PosEqLitSet    -> PosEqLitNeSet  [ctor ditto] .
-  op (_|_) : PosEqConjNeSet PosEqConjSet   -> PosEqConjNeSet [ctor ditto] .
-  op (_|_) : PosEqDisjNeSet PosEqDisjSet   -> PosEqDisjNeSet [ctor ditto] .
-  op (_|_) : PosEqFormNeSet PosEqFormSet   -> PosEqFormNeSet [ctor ditto] .
+  op (_|_) : PosConjNeSet PosConjSet   -> PosConjNeSet [ctor ditto] .
+  op (_|_) : PosDisjNeSet PosDisjSet   -> PosDisjNeSet [ctor ditto] .
+  op (_|_) : PosFormNeSet PosFormSet   -> PosFormNeSet [ctor ditto] .
   op (_|_) : NegEqLitNeSet  NegEqLitSet    -> NegEqLitNeSet  [ctor ditto] .
-  op (_|_) : NegEqConjNeSet NegEqConjSet   -> NegEqConjNeSet [ctor ditto] .
-  op (_|_) : NegEqDisjNeSet NegEqDisjSet   -> NegEqDisjNeSet [ctor ditto] .
-  op (_|_) : NegEqFormNeSet NegEqFormSet   -> NegEqFormNeSet [ctor ditto] .
+  op (_|_) : NegConjNeSet NegConjSet   -> NegConjNeSet [ctor ditto] .
+  op (_|_) : NegDisjNeSet NegDisjSet   -> NegDisjNeSet [ctor ditto] .
+  op (_|_) : NegFormNeSet NegFormSet   -> NegFormNeSet [ctor ditto] .
   op (_|_) : EqLitNeSet     EqLitSet       -> EqLitNeSet     [ctor ditto] .
   op (_|_) : EqConjNeSet    EqConjSet      -> EqConjNeSet    [ctor ditto] .
   op (_|_) : EqDisjNeSet    EqDisjSet      -> EqDisjNeSet    [ctor ditto] .

--- a/contrib/tools/meta.md/purification.md
+++ b/contrib/tools/meta.md/purification.md
@@ -203,20 +203,20 @@ fmod PURIFICATION is
    protecting BREAK-EQATOMS .
    protecting CTERM-SET .
 
-    vars Q Q' : Qid . vars F F' : Form .
+    vars Q Q' : Qid . var F : Form . vars CF CF' : NoTrueForm . vars DF DF' : NoFalseForm .
     vars ME ME' : ModuleExpression . vars M M' : Module . var MDS : ModuleDeclSet .
     vars FV : Variable . vars T T' T1 T2 : Term . var T? : [Term] . var CT : CTerm .
     vars NeTL NeTL' : NeTermList . vars TL TL' : TermList . vars TL? TL?' : [TermList] .
 
     op _in_ : Form Module -> Bool .
     -------------------------------
-    eq tt        in M = true .
-    eq ff        in M = true .
-    eq (~ F)     in M = F in M .
-   ceq (F /\ F') in M = (F in M) and (F' in M) if F =/= tt /\ F' =/= tt .
-   ceq (F \/ F') in M = (F in M) and (F' in M) if F =/= ff /\ F' =/= ff .
-    eq (T ?= T') in M = wellFormed(M, T) and wellFormed(M, T') .
-    eq (T != T') in M = wellFormed(M, T) and wellFormed(M, T') .
+    eq tt          in M = true .
+    eq ff          in M = true .
+    eq (~ F)       in M = F in M .
+    eq (CF /\ CF') in M = (CF in M) and (CF' in M) .
+    eq (DF \/ DF') in M = (DF in M) and (DF' in M) .
+    eq (T ?= T')   in M = wellFormed(M, T) and wellFormed(M, T') .
+    eq (T != T')   in M = wellFormed(M, T) and wellFormed(M, T') .
 ```
 
 Purifying Equational Conjunctions
@@ -241,12 +241,10 @@ If so, then it leaves it alone, otherwise more work is required on the equationa
 
     op purify : ModulePair Form -> [Form] .
     ---------------------------------------
-   ceq purify(modulePair(M, M'), F)       = F if (F in M) .
-    eq purify(modulePair(M, M'), ~ F)     = ~ purify(modulePair(M, M'), F) .
-   ceq purify(modulePair(M, M'), F /\ F') = purify(modulePair(M, M'), F) /\ purify(modulePair(M, M'), F')
-                                         if F =/= tt /\ F' =/= tt .
-   ceq purify(modulePair(M, M'), F \/ F') = purify(modulePair(M, M'), F) \/ purify(modulePair(M, M'), F')
-                                         if F =/= ff /\ F' =/= ff .
+   ceq purify(modulePair(M, M'), F)         = F if (F in M) .
+    eq purify(modulePair(M, M'), ~ F)       = ~ purify(modulePair(M, M'), F) .
+    eq purify(modulePair(M, M'), CF /\ CF') = purify(modulePair(M, M'), CF) /\ purify(modulePair(M, M'), CF') .
+    eq purify(modulePair(M, M'), DF \/ DF') = purify(modulePair(M, M'), DF) \/ purify(modulePair(M, M'), DF') .
 ```
 
 If a term in a (dis)equality is not `wellFormed` in either `Module`, then we purify it.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -1,24 +1,27 @@
+Warning: sort declarations for operator if_then_else_fi failed preregularity
+    check on 96 out of 13122 sort tuples. First such tuple is (Bool,
+    TrivTrueForm, EqForm).
 ==========================================
-reduce in EQFORM-TEST : ('_*_['Y:Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\
-    'true.Bool != '_<_['Y:Nat,'Z:Nat]) << (
-  'Y:Nat <- '3.Nat) == ('_*_['3.Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\
-    'true.Bool != '_<_['3.Nat,'Z:Nat]) .
-rewrites: 33
+reduce in EQFORM-TEST : ('_+_['1.Nat,'X:Nat] ?= '_*_['Y:Nat,'X:Nat] /\ '_<_[
+    'Y:Nat,'Z:Nat] != 'true.Bool) << (
+  'Y:Nat <- '3.Nat) == ('_+_['1.Nat,'X:Nat] ?= '_*_['3.Nat,'X:Nat] /\ '_<_[
+    '3.Nat,'Z:Nat] != 'true.Bool) .
+rewrites: 30
 result Bool: true
 ==========================================
-reduce in EQFORM-TEST : ('true.Bool != '_<_['Y:Nat,'Z:Nat] \/ '_*_['Y:Nat,
-    'X:Nat] != '_+_['1.Nat,'X:Nat]) << (
-  'X:Nat <- '7.Nat) == ('true.Bool != '_<_['Y:Nat,'Z:Nat] \/ '_*_['Y:Nat,
-    '7.Nat] != '_+_['1.Nat,'7.Nat]) .
-rewrites: 36
+reduce in EQFORM-TEST : ('_+_['1.Nat,'X:Nat] != '_*_['Y:Nat,'X:Nat] \/ '_<_[
+    'Y:Nat,'Z:Nat] != 'true.Bool) << (
+  'X:Nat <- '7.Nat) == ('_+_['1.Nat,'7.Nat] != '_*_['Y:Nat,'7.Nat] \/ '_<_[
+    'Y:Nat,'Z:Nat] != 'true.Bool) .
+rewrites: 30
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : f1 :: Form .
-rewrites: 7
+rewrites: 6
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : f2 :: Form .
-rewrites: 11
+rewrites: 9
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : ff .
@@ -38,44 +41,45 @@ rewrites: 0
 result Form: F:Form
 ==========================================
 reduce in EQFORM-TEST : nnf(f1) .
-rewrites: 111
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
-    'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 18
+result NonTrivForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ ('H:Baz ?= 'I:Wop
+    /\ 'H:Baz != 'I:Wop) \/ t1 != t2 /\ tt \/ 'F:Foo != 'G:Bar
 ==========================================
 reduce in EQFORM-TEST : nnf(f2) .
-rewrites: 132
-result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1
-    != t2 \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 27
+result NonTrivForm: 'U:Stu != 'W:Roc /\ (tt \/ 'H:Baz != 'I:Wop) /\ 'F:Foo ?=
+    'G:Bar \/ 'F:Foo != 'G:Bar \/ ('H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop) \/ t1
+    != t2 /\ tt \/ 'F:Foo != 'G:Bar
 ==========================================
 reduce in EQFORM-TEST : nef(f1) .
-rewrites: 113
+rewrites: 32
 result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
     'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : nef(f2) .
-rewrites: 134
+rewrites: 47
 result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1
     != t2 \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : cnf(f1) .
-rewrites: 628
+rewrites: 72
 result EqForm: ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/ 'F:Foo != 'G:Bar \/ t1
     != t2) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'H:Baz != 'I:Wop \/ t1 !=
     t2
 ==========================================
 reduce in EQFORM-TEST : cnf(f2) .
-rewrites: 695
+rewrites: 91
 result EqForm: 'U:Stu != 'W:Roc /\ ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/
     'F:Foo != 'G:Bar \/ t1 != t2) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
     'H:Baz != 'I:Wop \/ t1 != t2
 ==========================================
 reduce in EQFORM-TEST : dnf(f1) .
-rewrites: 238
+rewrites: 46
 result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
     'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : dnf(f2) .
-rewrites: 543
+rewrites: 93
 result EqForm: ('F:Foo ?= 'G:Bar /\ 'U:Stu != 'W:Roc) \/ ('F:Foo != 'G:Bar /\
     'U:Stu != 'W:Roc) \/ ('U:Stu != 'W:Roc /\ t1 != t2) \/ 'H:Baz ?= 'I:Wop /\
     'H:Baz != 'I:Wop /\ 'U:Stu != 'W:Roc

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -14,11 +14,11 @@ rewrites: 30
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : f1 :: Form .
-rewrites: 6
+rewrites: 7
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : f2 :: Form .
-rewrites: 9
+rewrites: 11
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : ff .
@@ -38,45 +38,44 @@ rewrites: 0
 result Form: F:Form
 ==========================================
 reduce in EQFORM-TEST : nnf(f1) .
-rewrites: 18
-result NonTrivForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ ('H:Baz ?= 'I:Wop
-    /\ 'H:Baz != 'I:Wop) \/ t1 != t2 /\ tt \/ 'F:Foo != 'G:Bar
+rewrites: 15
+result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
+    'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : nnf(f2) .
-rewrites: 27
-result NonTrivForm: 'U:Stu != 'W:Roc /\ (tt \/ 'H:Baz != 'I:Wop) /\ 'F:Foo ?=
-    'G:Bar \/ 'F:Foo != 'G:Bar \/ ('H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop) \/ t1
-    != t2 /\ tt \/ 'F:Foo != 'G:Bar
+rewrites: 21
+result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1
+    != t2 \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : nef(f1) .
-rewrites: 32
+rewrites: 17
 result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
     'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : nef(f2) .
-rewrites: 47
+rewrites: 23
 result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1
     != t2 \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : cnf(f1) .
-rewrites: 72
+rewrites: 57
 result EqForm: ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/ 'F:Foo != 'G:Bar \/ t1
     != t2) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'H:Baz != 'I:Wop \/ t1 !=
     t2
 ==========================================
 reduce in EQFORM-TEST : cnf(f2) .
-rewrites: 91
+rewrites: 67
 result EqForm: 'U:Stu != 'W:Roc /\ ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/
     'F:Foo != 'G:Bar \/ t1 != t2) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
     'H:Baz != 'I:Wop \/ t1 != t2
 ==========================================
 reduce in EQFORM-TEST : dnf(f1) .
-rewrites: 46
+rewrites: 31
 result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
     'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : dnf(f2) .
-rewrites: 93
+rewrites: 69
 result EqForm: ('F:Foo ?= 'G:Bar /\ 'U:Stu != 'W:Roc) \/ ('F:Foo != 'G:Bar /\
     'U:Stu != 'W:Roc) \/ ('U:Stu != 'W:Roc /\ t1 != t2) \/ 'H:Baz ?= 'I:Wop /\
     'H:Baz != 'I:Wop /\ 'U:Stu != 'W:Roc

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -13,6 +13,22 @@ reduce in EQFORM-TEST : ('true.Bool != '_<_['Y:Nat,'Z:Nat] \/ '_*_['Y:Nat,
 rewrites: 30
 result Bool: true
 ==========================================
+reduce in EQFORM-TEST : f1 << (
+  'F:Foo <- 'F2:Foo ; 
+  'I:Wop <- 'I2:Wop ; 
+  'U:Stu <- 'U2:Stu) .
+rewrites: 95
+result NonTrivForm: ~ ('F2:Foo ?= 'G:Bar /\ 'F2:Foo != 'G:Bar) \/ ~ ('K:Foo ?=
+    'L:Bar /\ 'H:Baz ?= 'I2:Wop \/ 'H:Baz != 'I2:Wop)
+==========================================
+reduce in EQFORM-TEST : f2 << (
+  'F:Foo <- 'F2:Foo ; 
+  'I:Wop <- 'I2:Wop ; 
+  'U:Stu <- 'U2:Stu) .
+rewrites: 121
+result NonTrivForm: ~ 'U2:Stu ?= 'W:Roc /\ ~ ('F2:Foo ?= 'G:Bar /\ 'F2:Foo !=
+    'G:Bar) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'I2:Wop \/ 'H:Baz != 'I2:Wop)
+==========================================
 reduce in EQFORM-TEST : f1 :: Form .
 rewrites: 7
 result Bool: true
@@ -39,44 +55,44 @@ result Form: F:Form
 ==========================================
 reduce in EQFORM-TEST : nnf(f1) .
 rewrites: 15
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
-    'I:Wop /\ 'H:Baz != 'I:Wop
+result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
+    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : nnf(f2) .
 rewrites: 21
-result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1
-    != t2 \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
+    'K:Foo != 'L:Bar \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : nef(f1) .
 rewrites: 17
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
-    'I:Wop /\ 'H:Baz != 'I:Wop
+result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
+    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : nef(f2) .
 rewrites: 23
-result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1
-    != t2 \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
+    'K:Foo != 'L:Bar \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : cnf(f1) .
 rewrites: 57
-result EqForm: ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/ 'F:Foo != 'G:Bar \/ t1
-    != t2) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'H:Baz != 'I:Wop \/ t1 !=
-    t2
+result EqForm: ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/ 'F:Foo != 'G:Bar \/
+    'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'H:Baz !=
+    'I:Wop \/ 'K:Foo != 'L:Bar
 ==========================================
 reduce in EQFORM-TEST : cnf(f2) .
 rewrites: 67
 result EqForm: 'U:Stu != 'W:Roc /\ ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/
-    'F:Foo != 'G:Bar \/ t1 != t2) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
-    'H:Baz != 'I:Wop \/ t1 != t2
+    'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo !=
+    'G:Bar \/ 'H:Baz != 'I:Wop \/ 'K:Foo != 'L:Bar
 ==========================================
 reduce in EQFORM-TEST : dnf(f1) .
 rewrites: 31
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ t1 != t2 \/ 'H:Baz ?=
-    'I:Wop /\ 'H:Baz != 'I:Wop
+result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
+    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
 ==========================================
 reduce in EQFORM-TEST : dnf(f2) .
 rewrites: 69
 result EqForm: ('F:Foo ?= 'G:Bar /\ 'U:Stu != 'W:Roc) \/ ('F:Foo != 'G:Bar /\
-    'U:Stu != 'W:Roc) \/ ('U:Stu != 'W:Roc /\ t1 != t2) \/ 'H:Baz ?= 'I:Wop /\
-    'H:Baz != 'I:Wop /\ 'U:Stu != 'W:Roc
+    'U:Stu != 'W:Roc) \/ ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) \/ 'H:Baz ?=
+    'I:Wop /\ 'H:Baz != 'I:Wop /\ 'U:Stu != 'W:Roc
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -1,15 +1,15 @@
 ==========================================
-reduce in EQFORM-TEST : ('_+_['1.Nat,'X:Nat] ?= '_*_['Y:Nat,'X:Nat] /\ '_<_[
-    'Y:Nat,'Z:Nat] != 'true.Bool) << (
-  'Y:Nat <- '3.Nat) == ('_+_['1.Nat,'X:Nat] ?= '_*_['3.Nat,'X:Nat] /\ '_<_[
-    '3.Nat,'Z:Nat] != 'true.Bool) .
+reduce in EQFORM-TEST : ('_*_['Y:Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\
+    'true.Bool != '_<_['Y:Nat,'Z:Nat]) << (
+  'Y:Nat <- '3.Nat) == ('_*_['3.Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\
+    'true.Bool != '_<_['3.Nat,'Z:Nat]) .
 rewrites: 30
 result Bool: true
 ==========================================
-reduce in EQFORM-TEST : ('_+_['1.Nat,'X:Nat] != '_*_['Y:Nat,'X:Nat] \/ '_<_[
-    'Y:Nat,'Z:Nat] != 'true.Bool) << (
-  'X:Nat <- '7.Nat) == ('_+_['1.Nat,'7.Nat] != '_*_['Y:Nat,'7.Nat] \/ '_<_[
-    'Y:Nat,'Z:Nat] != 'true.Bool) .
+reduce in EQFORM-TEST : ('true.Bool != '_<_['Y:Nat,'Z:Nat] \/ '_*_['Y:Nat,
+    'X:Nat] != '_+_['1.Nat,'X:Nat]) << (
+  'X:Nat <- '7.Nat) == ('true.Bool != '_<_['Y:Nat,'Z:Nat] \/ '_*_['Y:Nat,
+    '7.Nat] != '_+_['1.Nat,'7.Nat]) .
 rewrites: 30
 result Bool: true
 ==========================================

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -1,6 +1,3 @@
-Warning: sort declarations for operator if_then_else_fi failed preregularity
-    check on 96 out of 13122 sort tuples. First such tuple is (Bool,
-    TrivTrueForm, EqForm).
 ==========================================
 reduce in EQFORM-TEST : ('_+_['1.Nat,'X:Nat] ?= '_*_['Y:Nat,'X:Nat] /\ '_<_[
     'Y:Nat,'Z:Nat] != 'true.Bool) << (

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -16,7 +16,7 @@ fmod EQFORM-TEST is
   eq e = 'U:Stu ?= 'W:Roc .
 
   op f1 : -> Form .
-  eq f1 = ~ (a /\ b) \/ ~ ((c \/ d) /\ t1 ?= t2 \/ (a /\ ff)) .
+  eq f1 = ~ (a /\ b) \/ ~ ((c \/ d) /\ 'K:Foo ?= 'L:Bar \/ (a /\ ff)) .
 
   op f2 : -> Form .
   eq f2 = (f1 /\ ~ e) /\ (d \/ tt) .
@@ -28,6 +28,9 @@ reduce ('_+_['1.Nat, 'X:Nat] ?= '_*_['Y:Nat, 'X:Nat] /\ '_<_['Y:Nat, 'Z:Nat] != 
 
 reduce ('_+_['1.Nat, 'X:Nat] != '_*_['Y:Nat, 'X:Nat] \/ '_<_['Y:Nat, 'Z:Nat] != 'true.Bool) << ('X:Nat <- '7.Nat)
     == ('_+_['1.Nat, '7.Nat] != '_*_['Y:Nat, '7.Nat] \/ '_<_['Y:Nat, 'Z:Nat] != 'true.Bool) .
+
+reduce f1 << ('F:Foo <- 'F2:Foo ; 'I:Wop <- 'I2:Wop ; 'U:Stu <- 'U2:Stu) .
+reduce f2 << ('F:Foo <- 'F2:Foo ; 'I:Wop <- 'I2:Wop ; 'U:Stu <- 'U2:Stu) .
 
 --- sort check
 reduce f1 :: Form .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -7,7 +7,7 @@ fmod EQFORM-TEST is
   inc EQFORM-SET .
 
   ops t1 t2 : -> Term .
-  ops a b c d e : -> Lit .
+  ops a b c d e : -> EqLit .
 
   eq a = 'F:Foo ?= 'G:Bar .
   eq b = 'F:Foo != 'G:Bar .

--- a/tests/tools/meta/purification.expected
+++ b/tests/tools/meta/purification.expected
@@ -92,7 +92,7 @@ result CTerm: '_<_['#makeVariable`(head`[L1:NeNatList`]`):Nat,
 ==========================================
 reduce in TEST-PURIFY : purify(natListMod, natOrderMod, '_<_['head[
     'L1:NeNatList],'head['L2:NeNatList]]) .
-rewrites: 230
+rewrites: 200
 result CTerm: '#makeVariable`(_<_`[#makeVariable`(head`[L1:NeNatList`]`):Nat`,#makeVariable`(head`[L2:NeNatList`]`):Nat`]`):Bool st '#makeVariable`(_<_`[#makeVariable`(head`[L1:NeNatList`]`):Nat`,#makeVariable`(head`[L2:NeNatList`]`):Nat`]`):Bool ?= '_<_['#makeVariable`(head`[L1:NeNatList`]`):Nat,
     '#makeVariable`(head`[L2:NeNatList`]`):Nat] /\
     '#makeVariable`(head`[L1:NeNatList`]`):Nat ?= 'head['L1:NeNatList] /\
@@ -101,7 +101,7 @@ result CTerm: '#makeVariable`(_<_`[#makeVariable`(head`[L1:NeNatList`]`):Nat`,#m
 reduce in TEST-PURIFY : purify(natListMod, natOrderMod, '_<_['_+_['head[
     'L':NeNatList],'head['L':NeNatList]],'_+_['head['L:NeNatList],'head[
     'L:NeNatList]]]) .
-rewrites: 370
+rewrites: 340
 result CTerm: '#makeVariable`(_<_`[_+_`[#makeVariable`(head`[L':NeNatList`]`):Nat`,#makeVariable`(head`[L':NeNatList`]`):Nat`]`,_+_`[#makeVariable`(head`[L:NeNatList`]`):Nat`,#makeVariable`(head`[L:NeNatList`]`):Nat`]`]`):Bool st '#makeVariable`(_<_`[_+_`[#makeVariable`(head`[L':NeNatList`]`):Nat`,#makeVariable`(head`[L':NeNatList`]`):Nat`]`,_+_`[#makeVariable`(head`[L:NeNatList`]`):Nat`,#makeVariable`(head`[L:NeNatList`]`):Nat`]`]`):Bool ?= '_<_['_+_[
     '#makeVariable`(head`[L':NeNatList`]`):Nat,
     '#makeVariable`(head`[L':NeNatList`]`):Nat],'_+_[
@@ -133,7 +133,7 @@ result CTerm: '#makeVariable`(_+_`[_*_`[min`[_*_`[max`[_*_`[_+_`[1.Nat`,1.Nat`]`
 ==========================================
 reduce in TEST-PURIFY : purify('MYLISTNAT, 'FVP-NAT-PRED, 'true.Bool ?= '_<_[
     'head['L1:NeNatList],'head['L2:NeNatList]]) .
-rewrites: 338
+rewrites: 206
 result PosEqConj: '#makeVariable`(head`[L1:NeNatList`]`):Nat ?= 'head[
     'L1:NeNatList] /\ '#makeVariable`(head`[L2:NeNatList`]`):Nat ?= 'head[
     'L2:NeNatList] /\ 'true.Bool ?= '_<_[
@@ -143,7 +143,7 @@ result PosEqConj: '#makeVariable`(head`[L1:NeNatList`]`):Nat ?= 'head[
 reduce in TEST-PURIFY : purify('FVP-NAT-PRED, 'MYLISTNAT, 'true.Bool != '_<_[
     '_+_['head['L':NeNatList],'head['L':NeNatList]],'_+_['head['L:NeNatList],
     'head['L:NeNatList]]]) .
-rewrites: 456
+rewrites: 324
 result EqConj: '#makeVariable`(head`[L':NeNatList`]`):Nat ?= 'head[
     'L':NeNatList] /\ '#makeVariable`(head`[L:NeNatList`]`):Nat ?= 'head[
     'L:NeNatList] /\ 'true.Bool != '_<_['_+_[
@@ -155,7 +155,7 @@ result EqConj: '#makeVariable`(head`[L':NeNatList`]`):Nat ?= 'head[
 reduce in TEST-PURIFY : purify('MYLISTNAT, 'FVP-NAT-PRED, 'false.Bool != '_<_[
     '_+_['head['L':NeNatList],'head['L':NeNatList]],'_+_['head['L:NeNatList],
     'head['L:NeNatList]]]) .
-rewrites: 456
+rewrites: 324
 result EqConj: '#makeVariable`(head`[L':NeNatList`]`):Nat ?= 'head[
     'L':NeNatList] /\ '#makeVariable`(head`[L:NeNatList`]`):Nat ?= 'head[
     'L:NeNatList] /\ 'false.Bool != '_<_['_+_[


### PR DESCRIPTION
I made a note on the previous, closed pull request, before realizing that is a better idea to open a new pull request, so here goes:

Key Changes:
- sort structure now distinguishes between three cases: trivially true formulas, trivially false formulas, and non-trivial formulas (a trivially true/false formula will be evaluated to true/false by the identity axioms)
- equations that failed to terminate previously now terminate without using any conditional equation hacks
- sort structure is preregular ~~(modulo adding more top-most sorts to stop Maude from complaining about `if_then_else_fi`)~~
- documentation formatting has been normalized and more explanatory text is included
- there are now 22 base sorts: 4 needed to be added to make `if_then_else_fi` preregular
- for the heck of it, I added a `Lit` sort back in that I had previously removed; this requires adding 3 additional sorts for `if_then_else_fi` preregularity, for a grand total of 30 sorts, which is still far less than the 57 or so in `FOForm?`

I previously pushed my changes on top of `tools/varsat-update` before moving them to this topic branch, so your repo state may be out of sync on `tools/varsat-update` if you fetched in the last 8 hours or so.