### PR TITLE
Unconditionalize operation for turning conditional systems into unconditional systems

### DIFF
--- a/build
+++ b/build
@@ -77,11 +77,11 @@ build_maude() {
 
     ./configure CXXFLAGS="-std=c++11 -I$include_dir -L$lib_dir" "$@"
     make -s -j4 \
-        || ( git checkout -- src/Mixfix/surface.cc
+        || ( git checkout -- src/Mixfix/{surface.cc,tokenizer.cc}
              make -s -j4
            )
 
-    git checkout -- src/Mixfix/surface.cc
+    git checkout -- src/Mixfix/{surface.cc,tokenizer.cc}
 }
 
 build_maude_cvc4() {

--- a/contrib/systems.md/bank-account.md
+++ b/contrib/systems.md/bank-account.md
@@ -71,7 +71,8 @@ mod BANK-ACCOUNT is
     *** more money can at any time be deposited in the account if it is not in overdraft
 
     rl [overdraft] : < bal: n     pend: x overdraft: false > # msgs
-                  => < bal: n + m pend: x overdraft: false > # msgs .
+                  => < bal: n + m pend: x overdraft: false > # msgs
+       [narrowing nonexec] .
 endm
 ```
 
@@ -141,6 +142,6 @@ mod BANK-ACCOUNT-CTOR is
 
     rl [deposit] : < bal: n     pend: x overdraft: false > # msgs
                 => < bal: n + m pend: x overdraft: false > # msgs
-       [narrowing] .
+       [narrowing nonexec] .
 endm
 ```

--- a/contrib/systems.md/bank-account.md
+++ b/contrib/systems.md/bank-account.md
@@ -17,6 +17,8 @@ Here is the high-level specification of the bank account system.
 mod BANK-ACCOUNT is
    protecting FVP-NAT-PRED .
 
+    var N : Nat . var MSGS : MsgConf .
+
     sorts Msg MsgConf .
     -------------------
     subsort Msg < MsgConf .
@@ -24,6 +26,11 @@ mod BANK-ACCOUNT is
     op withdraw : Nat -> Msg [ctor] .
     op mt       : -> MsgConf [ctor] .
     op _,_ : MsgConf MsgConf -> MsgConf [ctor assoc comm id: mt] .
+
+    op debts : MsgConf -> Nat .
+    ---------------------------
+    eq debts(mt)                 = 0 .
+    eq debts(withdraw(N) , MSGS) = N + debts(MSGS) .
 
     sort Account .
     ------------
@@ -74,6 +81,8 @@ After performing constructor decomposition, you should arrive at this specificat
 mod BANK-ACCOUNT-CTOR is
    protecting FVP-NAT-PRED .
 
+    var N : Nat . var MSGS : MsgConf .
+
     sorts Msg MsgConf .
     -------------------
     subsort Msg < MsgConf .
@@ -81,6 +90,11 @@ mod BANK-ACCOUNT-CTOR is
     op withdraw : Nat -> Msg [ctor] .
     op mt       : -> MsgConf [ctor] .
     op _,_ : MsgConf MsgConf -> MsgConf [ctor assoc comm id: mt] .
+
+    op debts : MsgConf -> Nat .
+    ---------------------------
+    eq debts(mt)                 = 0 .
+    eq debts(withdraw(N) , MSGS) = N + debts(MSGS) .
 
     sort Account .
     --------------
@@ -128,24 +142,5 @@ mod BANK-ACCOUNT-CTOR is
     rl [deposit] : < bal: n     pend: x overdraft: false > # msgs
                 => < bal: n + m pend: x overdraft: false > # msgs
        [narrowing] .
-endm
-```
-
-Defined Operations
-------------------
-
-The following operations help to specify claims about the bank account system.
-
-```maude
-mod BANK-ACCOUNT-DEFINEDOPS is
-   protecting BANK-ACCOUNT-CTOR .
-   protecting FVP-BOOL-EQFORM .
-
-    var N : Nat . var MSGS : MsgConf .
-
-    op debts : MsgConf -> Nat .
-    ---------------------------
-    eq debts(mt)                 = 0 .
-    eq debts(withdraw(N) , MSGS) = N + debts(MSGS) .
 endm
 ```

--- a/contrib/tools/fvp.md/numbers.md
+++ b/contrib/tools/fvp.md/numbers.md
@@ -11,6 +11,8 @@ For instantiating for formulae over FVP naturals, we'll use the `eqform` package
 
 ```maude
 load ../meta/eqform.maude
+load ../meta/mtransform.maude
+load ../meta/variables.maude
 ```
 
 FVP Booleans
@@ -238,4 +240,30 @@ endfm
 
 fmod FVP-NAT-EQFORM is protecting EQFORM-IMPL{Nat} . endfm
 fmod FVP-INT-EQFORM is protecting EQFORM-IMPL{Int} . endfm
+```
+
+Unconditionalizing Theories with FVP Natural conditions
+-------------------------------------------------------
+
+Instantiations of this still must specify the top sort of the target rewrite system (`#tSort`).
+
+```maude
+fmod UNCONDITIONALIZE-FVP-BOOL is
+    including UNCONDITIONALIZE .
+   protecting DETERMINISTIC-VARIABLES .
+
+    vars T T' : Term . var S : Sort . vars EqC EqC' : EqCondition .
+
+    eq #cModule   = 'FVP-BOOL-EQFORM .
+    eq #cSort     = 'Form`{Bool`} .
+    eq #cTrue     = 'tt.TrueLit`{Bool`} .
+    eq #cFalse    = 'ff.FalseLit`{Bool`} .
+    eq #cConjunct = '_/\_ .
+    -----------------------
+
+    eq #mkCondition(T  = T') = '_?=_[T, T'] .
+    eq #mkCondition(T := T') = '_?=_[T, T'] .
+    eq #mkCondition(T : S)   = '_?=_[T, #var(T, S)] .
+    -------------------------------------------------
+endfm
 ```

--- a/contrib/tools/lmc.md/lgraph-search.md
+++ b/contrib/tools/lmc.md/lgraph-search.md
@@ -314,20 +314,20 @@ endfm
 ### Conditional Narrowing
 
 ```maude
-fmod FVP-NARROWING-MODULO-T-GRAPH is
+fmod FVP-CONDITIONAL-NARROWING-GRAPH is
    protecting FVP-NARROWING-GRAPH .
-    extending META-CONDITIONAL-LMC-PARAMETERS .
+   protecting META-CONDITIONAL-LMC-PARAMETERS .
 
     vars ND ND' : Node . vars T T' C C' : Term .
     var Q : Qid . var SUB : Substitution . var N : Nat .
 
-    op foldAny  : Node Node Nat -> [Fold] .
-    ---------------------------------------
+    op foldAny : Node Node Nat -> [Fold] .
+    --------------------------------------
     eq fold(ND, ND') = foldAny(ND, ND', 0) [owise] .
 
    ceq foldAny(ND, ND', N) = if implies?(C << SUB, C' << SUB) then fold(SUB) else foldAny(ND, ND', s N) fi
-                          if state(Q[T,  C ]) := ND  /\ Q == #ST
-                          /\ state(Q[T', C']) := ND' /\ Q == #ST
+                          if state(Q[T  , C ]) := ND  /\ Q == #cTerm
+                          /\ state(Q[T' , C']) := ND' /\ Q == #cTerm
                           /\ SUB := metaMatch(#M, T', T, nil, N) .
 ```
 

--- a/contrib/tools/lmc.md/lmc.md
+++ b/contrib/tools/lmc.md/lmc.md
@@ -11,40 +11,31 @@ Model Checking
 --------------
 
 -   `#M` should be filled in as the module to do simulation of.
--   `#FS` shoudl be filled in as the term list of atomic propositions that will be used.
+-   `#FS` should be filled in as the term list of atomic propositions that will be used.
 
 ```maude
 fmod META-LMC-PARAMETERS is
    protecting META-MODULE .
 
-    op #M  : ~> SModule  [memo] .
-    op #FS : ~> TermList [memo] .
+    op #M  : -> [SModule]  [memo] .
+    op #FS : -> [TermList] [memo] .
+    -------------------------------
 endfm
 ```
 
 Conditional Model Checking
 --------------------------
 
--   `#MO` should be filled as the module with the original system.
--   `#MC` should be filled as the module to resolve conditions in.
--   `#T` should be filled as the topmost rewriting sort of `#M` from `META-LMC-PARAMETERS`.
--   `#C` should be filled as the sort of conditions.
--   `#ST` should be filled as a suitable operator for holding a tuple of `#T` and `#C` (which won't clash with operators from `#M` or `#MC`).
+-   `#MO` should be filled as the original module with conditional rules instead of `#M`.
+-   The parameters of module `UNCONDITIONALIZE` should be filled in as well.
 
 ```maude
 fmod META-CONDITIONAL-LMC-PARAMETERS is
    protecting META-LMC-PARAMETERS .
    protecting UNCONDITIONALIZE .
 
-    op #MC : ~> SModule [memo] .
-    op #MO : ~> SModule [memo] .
-    op #T  : ~> Sort    [memo] .
-    op #C  : ~> Sort    [memo] .
-    op #ST : ~> Qid     [memo] .
-    ----------------------------
-
-    op #M : ~> SModule [memo] .
-    ---------------------------
-    eq #M = unconditionalize(#T, #C, #ST, getName(#MC), #MO) .
+    op #MO : -> [SModule] [memo] .
+    ------------------------------
+    eq #M = unconditionalize(#MO) .
 endfm
 ```

--- a/contrib/tools/meta.md/mtemplate.md
+++ b/contrib/tools/meta.md/mtemplate.md
@@ -71,6 +71,34 @@ fmod MODULE-DECLARATION is
     eq NeMDS NeMDS = NeMDS .
 ```
 
+Here we have faster projections than matching on the overall `ModuleDeclSet`.
+
+```maude
+    op  importDeclSet : ModuleDeclSet -> [ModuleDeclSet] .
+    op    sortDeclSet : ModuleDeclSet -> [ModuleDeclSet] .
+    op subsortDeclSet : ModuleDeclSet -> [ModuleDeclSet] .
+    op      opDeclSet : ModuleDeclSet -> [ModuleDeclSet] .
+    op      membAxSet : ModuleDeclSet -> [ModuleDeclSet] .
+    op    equationSet : ModuleDeclSet -> [ModuleDeclSet] .
+    op        ruleSet : ModuleDeclSet -> [ModuleDeclSet] .
+    ------------------------------------------------------
+    eq  importDeclSet(MD MDS) = if (MD ::  ImportDecl) then MD else none fi  importDeclSet(MDS) .
+    eq    sortDeclSet(MD MDS) = if (MD ::    SortDecl) then MD else none fi    sortDeclSet(MDS) .
+    eq subsortDeclSet(MD MDS) = if (MD :: SubsortDecl) then MD else none fi subsortDeclSet(MDS) .
+    eq      opDeclSet(MD MDS) = if (MD ::      OpDecl) then MD else none fi      opDeclSet(MDS) .
+    eq      membAxSet(MD MDS) = if (MD ::      MembAx) then MD else none fi      membAxSet(MDS) .
+    eq    equationSet(MD MDS) = if (MD ::    Equation) then MD else none fi    equationSet(MDS) .
+    eq        ruleSet(MD MDS) = if (MD ::        Rule) then MD else none fi        ruleSet(MDS) .
+
+    eq  importDeclSet(none) = none .
+    eq    sortDeclSet(none) = none .
+    eq subsortDeclSet(none) = none .
+    eq      opDeclSet(none) = none .
+    eq      membAxSet(none) = none .
+    eq    equationSet(none) = none .
+    eq        ruleSet(none) = none .
+```
+
 Using the syntax of the prelude, imports and sort declarations are treated specially.
 Here we add the notion of `ImportDecl` and `SortDecl`, so that they can be treated uniformly with the rest of the declarations.
 

--- a/contrib/tools/meta.md/mtransform.md
+++ b/contrib/tools/meta.md/mtransform.md
@@ -151,12 +151,17 @@ It's parametric in several operators and sorts (prefixed below with `#`) about t
     eq unconditionalizeRules(none)         = none .
     eq unconditionalizeRules(NeRLS NeRLS') = unconditionalizeRules(NeRLS) unconditionalizeRules(NeRLS') .
 
-   ceq unconditionalizeRules(rl T => T' [AS] .) = ( rl #cTerm[T, V] => #cTerm[T', V] [narrowing AS] . )
+   ceq unconditionalizeRules(rl T => T' [AS] .) = ( rl #cTerm[T, V] => #cTerm[T', V] [narrowing #noNonExec(AS)] . )
     if V := qid("###COND###:" + string(#cSort)) .
 
-   ceq unconditionalizeRules(crl T => T' if EqC [AS] .) = ( rl #cTerm[T, V] => #cTerm[T', C'] [narrowing AS] . )
+   ceq unconditionalizeRules(crl T => T' if EqC [AS] .) = ( rl #cTerm[T, V] => #cTerm[T', C'] [narrowing #noNonExec(AS)] . )
     if V  := qid("###COND###:" + string(#cSort))
     /\ C' := #cConjunct[V, #mkCondition(EqC)] .
+
+    op #noNonExec : AttrSet -> [AttrSet] .
+    --------------------------------------
+    eq #noNonExec(none) = none .
+    eq #noNonExec(A AS) = if A == nonexec then none else A fi #noNonExec(AS) .
 ```
 
 The parameters of the transformation are as follows:

--- a/contrib/tools/meta.md/mtransform.md
+++ b/contrib/tools/meta.md/mtransform.md
@@ -141,5 +141,18 @@ This also assumes that the given theory is topmost.
     eq stripConditions(NeMDS NeMDS')                = stripConditions(NeMDS) stripConditions(NeMDS') .
     eq stripConditions(  rl T => T'      [ AS ] . ) = ( rl T => T' [ AS ] . ) .
     eq stripConditions( crl T => T' if C [ AS ] . ) = ( rl T => T' [ AS ] . ) .
+
+    op stripConditions : Module -> [Module] .
+    -----------------------------------------
+    eq stripConditions(M) = fromTemplate(getName(M), stripConditions(asTemplate(M))) .
+
+    op conditionFor : Qid ModuleDeclSet -> [Condition] .
+    ----------------------------------------------------
+    eq conditionFor(Q, crl T => T' if C [ label(Q) AS ] . MDS) = C   .
+    eq conditionFor(Q,  rl T => T'      [ label(Q) AS ] . MDS) = nil .
+
+    op conditionFor : Qid Module -> [Condition] .
+    ---------------------------------------------
+    eq conditionFor(Q, M) = conditionFor(Q, asTemplate(M)) .
 endfm
 ```

--- a/contrib/tools/meta.md/narrowing.md
+++ b/contrib/tools/meta.md/narrowing.md
@@ -2,11 +2,6 @@ Narrowing
 =========
 
 Several narrowing utilities/wrappers are provided here.
-Much of this code is extracted from Santiago Escobar's [unification.md].
-
-```maude
-load cterms.maude
-```
 
 ```maude
 load terms.maude

--- a/contrib/tools/meta.md/narrowing.md
+++ b/contrib/tools/meta.md/narrowing.md
@@ -8,12 +8,17 @@ Much of this code is extracted from Santiago Escobar's [unification.md].
 load cterms.maude
 ```
 
+```maude
+load terms.maude
+```
+
 Variant Sets
 ------------
 
 ```maude
 fmod VARIANT-SET is
    protecting META-LEVEL .
+   protecting TERM-SET .
 
     var N N' : Nat . var P : Parent . var B : Bool .
     var M : Module . var T : Term . var SUB : Substitution .
@@ -38,10 +43,10 @@ fmod VARIANT-SET is
    ceq allVariants(M, T, N) = V # allVariants(M, T, N + 1)
     if V := metaGetIrredundantVariant(M, T, empty, 0, N) .
 
-    op getTerms : VariantSet -> TermList .
-    --------------------------------------
-    eq getTerms(.VariantSet)            = empty .
-    eq getTerms({T, SUB, N, P, B} # VS) = T , getTerms(VS) .
+    op getTerms : VariantSet -> TermSet .
+    -------------------------------------
+    eq getTerms(.VariantSet)            = .TermSet .
+    eq getTerms({T, SUB, N, P, B} # VS) = T | getTerms(VS) .
 endfm
 ```
 

--- a/contrib/tools/meta.md/terms.md
+++ b/contrib/tools/meta.md/terms.md
@@ -39,6 +39,7 @@ Substitution Sets
 ```maude
 fmod SUBSTITUTION-SET is
    protecting TERM-SET .
+   protecting EXT-BOOL .
 
     sort SubstitutionSet NeSubstitutionSet .
     ----------------------------------------
@@ -85,6 +86,11 @@ fmod SUBSTITUTION-SET is
 
     eq SUBS << .SubstitutionSet   = .SubstitutionSet .
     eq SUBS << (NeSUBS | NeSUBS') = (SUBS << NeSUBS) | (SUBS << NeSUBS') .
+
+    op isRenaming : Substitution -> Bool .
+    --------------------------------------
+    eq isRenaming(none)         = true .
+    eq isRenaming(V <- T ; SUB) = (T :: Variable) and-then isRenaming(SUB) .
 endfm
 ```
 

--- a/tests/systems/bank-account.expected
+++ b/tests/systems/bank-account.expected
@@ -1,11 +1,3 @@
-Warning: "bank-account.maude", line 73 (mod BANK-ACCOUNT): variable m is used
-    before it is bound in rule:
-rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
-    overdraft: false > # msgs [label overdraft] .
-Warning: "bank-account.maude", line 142 (mod BANK-ACCOUNT-CTOR): variable m is
-    used before it is bound in rule:
-rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
-    overdraft: false > # msgs [narrowing label deposit] .
 ==========================================
 get variants in BANK-ACCOUNT : [< bal: n + m + x pend: x overdraft: false > #
     msgs,< bal: n + m + x pend: m + x overdraft: false > # msgs,withdraw(m)] .

--- a/tests/systems/bank-account.expected
+++ b/tests/systems/bank-account.expected
@@ -1,8 +1,8 @@
-Warning: "bank-account.maude", line 66 (mod BANK-ACCOUNT): variable m is used
+Warning: "bank-account.maude", line 73 (mod BANK-ACCOUNT): variable m is used
     before it is bound in rule:
 rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
     overdraft: false > # msgs [label overdraft] .
-Warning: "bank-account.maude", line 128 (mod BANK-ACCOUNT-CTOR): variable m is
+Warning: "bank-account.maude", line 142 (mod BANK-ACCOUNT-CTOR): variable m is
     used before it is bound in rule:
 rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
     overdraft: false > # msgs [narrowing label deposit] .

--- a/tests/tools/lmc/bank-account.expected
+++ b/tests/tools/lmc/bank-account.expected
@@ -1,11 +1,3 @@
-Warning: "bank-account.maude", line 73 (mod BANK-ACCOUNT): variable m is used
-    before it is bound in rule:
-rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
-    overdraft: false > # msgs [label overdraft] .
-Warning: "bank-account.maude", line 142 (mod BANK-ACCOUNT-CTOR): variable m is
-    used before it is bound in rule:
-rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
-    overdraft: false > # msgs [narrowing label deposit] .
 Warning: sort declarations for operator resolveNames failed preregularity check
     on 6 out of 40 sort tuples. First such tuple is (Type).
 Warning: sort declarations for operator resolveNames failed preregularity check

--- a/tests/tools/lmc/bank-account.expected
+++ b/tests/tools/lmc/bank-account.expected
@@ -15,7 +15,7 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     SortDeclSet).
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : #M .
-rewrites: 581
+rewrites: 60
 result SModule: mod 'BANK-ACCOUNT-CTOR is
   protecting 'BANK-ACCOUNT-DEFINEDOPS .
   protecting 'FVP-NAT-PRED .
@@ -24,7 +24,7 @@ result SModule: mod 'BANK-ACCOUNT-CTOR is
   op '<`bal:_pend:_overdraft:_> : 'Nat 'Nat 'Bool -> 'Account [ctor] .
   op '_#_ : 'Account 'MsgConf -> 'State [ctor] .
   op '_`,_ : 'MsgConf 'MsgConf -> 'MsgConf [assoc comm ctor id('mt.MsgConf)] .
-  op '_|_ : 'State 'Form`{Bool`} -> 'CState [none] .
+  op '_st_ : 'State 'Form`{Bool`} -> 'CState [ctor prec(57)] .
   op '`[_`,_`,_`] : 'Bool 'State 'State -> 'State [frozen(1 2 3)] .
   op '`[_`,_`] : 'State 'State -> 'StatePair [ctor] .
   op 'mt : nil -> 'MsgConf [ctor] .
@@ -32,30 +32,35 @@ result SModule: mod 'BANK-ACCOUNT-CTOR is
   none
   eq '`[_`,_`,_`]['false.Bool,'s:State,'s':State] = 's':State [variant] .
   eq '`[_`,_`,_`]['true.Bool,'s:State,'s':State] = 's:State [variant] .
-  rl '_|_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,'N2:Nat,'false.Bool],'_`,_[
-    'M3:MsgConf,'withdraw['_+_['1.NzNat,'N1:Nat,'N4:Nat]]]],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,N2:Nat`,false.Bool`]`,_`,_`[M3:MsgConf`,withdraw`[_+_`[1.NzNat`,N1:Nat`,N4:Nat`]`]`]`]`,_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,N2:Nat`,true.Bool`]`,M3:MsgConf`]`):Form`{Bool`}] => '_|_['_#_[
-    '<`bal:_pend:_overdraft:_>['N1:Nat,'N2:Nat,'true.Bool],'M3:MsgConf],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,N2:Nat`,false.Bool`]`,_`,_`[M3:MsgConf`,withdraw`[_+_`[1.NzNat`,N1:Nat`,N4:Nat`]`]`]`]`,_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,N2:Nat`,true.Bool`]`,M3:MsgConf`]`):Form`{Bool`}] [narrowing
+  rl '_st_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,'N2:Nat,'false.Bool],'_`,_[
+    'M3:MsgConf,'withdraw['_+_['1.NzNat,'N1:Nat,'N4:Nat]]]],
+    '###COND###:Form`{Bool`}] => '_st_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,
+    'N2:Nat,'true.Bool],'M3:MsgConf],'###COND###:Form`{Bool`}] [narrowing
     label('overdraft)] .
-  rl '_|_['_#_['<`bal:_pend:_overdraft:_>['n:Nat,'x:Nat,'false.Bool],
-    'msgs:MsgConf],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[n:Nat`,x:Nat`,false.Bool`]`,msgs:MsgConf`]`,_#_`[<`bal:_pend:_overdraft:_>`[_+_`[n:Nat`,m:Nat`]`,x:Nat`,false.Bool`]`,msgs:MsgConf`]`):Form`{Bool`}] => '_|_['_#_[
+  rl '_st_['_#_['<`bal:_pend:_overdraft:_>['n:Nat,'x:Nat,'false.Bool],
+    'msgs:MsgConf],'###COND###:Form`{Bool`}] => '_st_['_#_[
     '<`bal:_pend:_overdraft:_>['_+_['n:Nat,'m:Nat],'x:Nat,'false.Bool],
-    'msgs:MsgConf],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[n:Nat`,x:Nat`,false.Bool`]`,msgs:MsgConf`]`,_#_`[<`bal:_pend:_overdraft:_>`[_+_`[n:Nat`,m:Nat`]`,x:Nat`,false.Bool`]`,msgs:MsgConf`]`):Form`{Bool`}] [nonexec narrowing
-    label('deposit)] .
-  rl '_|_['_#_['<`bal:_pend:_overdraft:_>['_+_['N1:Nat,'N3:Nat],'_+_['N3:Nat,
-    'N4:Nat],'false.Bool],'_`,_['M2:MsgConf,'withdraw['N3:Nat]]],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[_+_`[N1:Nat`,N3:Nat`]`,_+_`[N3:Nat`,N4:Nat`]`,false.Bool`]`,_`,_`[M2:MsgConf`,withdraw`[N3:Nat`]`]`]`,_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,N4:Nat`,false.Bool`]`,M2:MsgConf`]`):Form`{Bool`}] => '_|_['_#_[
-    '<`bal:_pend:_overdraft:_>['N1:Nat,'N4:Nat,'false.Bool],'M2:MsgConf],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[_+_`[N1:Nat`,N3:Nat`]`,_+_`[N3:Nat`,N4:Nat`]`,false.Bool`]`,_`,_`[M2:MsgConf`,withdraw`[N3:Nat`]`]`]`,_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,N4:Nat`,false.Bool`]`,M2:MsgConf`]`):Form`{Bool`}] [
-    narrowing label('doWithdrawal2)] .
-  rl '_|_['_#_['<`bal:_pend:_overdraft:_>['_+_['N1:Nat,'N3:Nat,'N4:Nat],
-    'N3:Nat,'false.Bool],'_`,_['M2:MsgConf,'withdraw['_+_['N3:Nat,'N4:Nat]]]],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[_+_`[N1:Nat`,N3:Nat`,N4:Nat`]`,N3:Nat`,false.Bool`]`,_`,_`[M2:MsgConf`,withdraw`[_+_`[N3:Nat`,N4:Nat`]`]`]`]`,_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,0.Nat`,false.Bool`]`,M2:MsgConf`]`):Form`{Bool`}] => '_|_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,'0.Nat,'false.Bool],
-    'M2:MsgConf],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[_+_`[N1:Nat`,N3:Nat`,N4:Nat`]`,N3:Nat`,false.Bool`]`,_`,_`[M2:MsgConf`,withdraw`[_+_`[N3:Nat`,N4:Nat`]`]`]`]`,_#_`[<`bal:_pend:_overdraft:_>`[N1:Nat`,0.Nat`,false.Bool`]`,M2:MsgConf`]`):Form`{Bool`}] [narrowing label('doWithdrawal1)] .
-  rl '_|_['_#_['<`bal:_pend:_overdraft:_>['_+_['n:Nat,'m:Nat,'x:Nat],'x:Nat,
-    'false.Bool],'msgs:MsgConf],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[_+_`[n:Nat`,m:Nat`,x:Nat`]`,x:Nat`,false.Bool`]`,msgs:MsgConf`]`,_#_`[<`bal:_pend:_overdraft:_>`[_+_`[n:Nat`,_+_`[m:Nat`,x:Nat`]`]`,_+_`[m:Nat`,x:Nat`]`,false.Bool`]`,_`,_`[msgs:MsgConf`,withdraw`[m:Nat`]`]`]`):Form`{Bool`}] => '_|_['_#_[
+    'msgs:MsgConf],'###COND###:Form`{Bool`}] [nonexec narrowing label(
+    'deposit)] .
+  rl '_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['N1:Nat,'N3:Nat],'_+_['N3:Nat,
+    'N4:Nat],'false.Bool],'_`,_['M2:MsgConf,'withdraw['N3:Nat]]],
+    '###COND###:Form`{Bool`}] => '_st_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,
+    'N4:Nat,'false.Bool],'M2:MsgConf],'###COND###:Form`{Bool`}] [narrowing
+    label('doWithdrawal2)] .
+  rl '_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['N1:Nat,'N3:Nat,'N4:Nat],
+    'N3:Nat,'false.Bool],'_`,_['M2:MsgConf,'withdraw['_+_['N3:Nat,'N4:Nat]]]],
+    '###COND###:Form`{Bool`}] => '_st_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,
+    '0.Nat,'false.Bool],'M2:MsgConf],'###COND###:Form`{Bool`}] [narrowing
+    label('doWithdrawal1)] .
+  rl '_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['n:Nat,'m:Nat,'x:Nat],'x:Nat,
+    'false.Bool],'msgs:MsgConf],'###COND###:Form`{Bool`}] => '_st_['_#_[
     '<`bal:_pend:_overdraft:_>['_+_['n:Nat,'_+_['m:Nat,'x:Nat]],'_+_['m:Nat,
-    'x:Nat],'false.Bool],'_`,_['msgs:MsgConf,'withdraw['m:Nat]]],'#makeVariable`(_#_`[<`bal:_pend:_overdraft:_>`[_+_`[n:Nat`,m:Nat`,x:Nat`]`,x:Nat`,false.Bool`]`,msgs:MsgConf`]`,_#_`[<`bal:_pend:_overdraft:_>`[_+_`[n:Nat`,_+_`[m:Nat`,x:Nat`]`]`,_+_`[m:Nat`,x:Nat`]`,false.Bool`]`,_`,_`[msgs:MsgConf`,withdraw`[m:Nat`]`]`]`):Form`{Bool`}] [narrowing label('initWithdrawal)] .
+    'x:Nat],'false.Bool],'_`,_['msgs:MsgConf,'withdraw['m:Nat]]],
+    '###COND###:Form`{Bool`}] [narrowing label('initWithdrawal)] .
 endm
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : #MC .
-rewrites: 1
+rewrites: 3
 result SModule: mod 'BANK-ACCOUNT-DEFINEDOPS is
   protecting 'BANK-ACCOUNT-CTOR .
   protecting 'FVP-BOOL-EQFORM .
@@ -111,7 +116,7 @@ rewrites: 2
 result Bool: true
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : wellFormed(#MC) .
-rewrites: 2
+rewrites: 4
 result Bool: true
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : wellFormed(#MO) .
@@ -308,9 +313,9 @@ result FoldedLabeledGraph: (0 -[label('deposit,
   '@2:Form`{Bool`} <- '@5:Form`{Bool`} ; 
   '@3:MsgConf <- '@2:MsgConf ; 
   '@4:Nat <- '@3:Nat)])
-| 0 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],
+| 0 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],
     'MSGS:MsgConf],'C:Form`{Bool`}])
-18 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['@4:Nat,'@1:Nat,'true.Bool],
+18 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@4:Nat,'@1:Nat,'true.Bool],
     '@3:MsgConf],'@2:Form`{Bool`}])
 | 21
 ==========================================
@@ -327,7 +332,7 @@ Warning: unsafe variable name @2:Nat in variant narrowing problem.
 Warning: unsafe variable name @2:Nat in variant narrowing problem.
 Warning: unsafe variable name %1:Nat in variant narrowing problem.
 Warning: unsafe variable name @3:Nat in variant narrowing problem.
-rewrites: 1290
+rewrites: 1338
 result FoldedLabeledGraph?: (0 -[label('deposit, 
   'MSGS:MsgConf <- '%1:MsgConf ; 
   'N:Nat <- '%2:Nat ; 
@@ -407,22 +412,23 @@ result FoldedLabeledGraph?: (0 -[label('deposit,
     ; 
   'N:Nat <- '@3:Nat ; 
   'X:Nat <- '@1:Nat)]-> 26)
-| 0 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],
+| 0 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],
     'MSGS:MsgConf],'_?=_['true.Bool,'_<=_['X:Nat,'N:Nat]]])
-2 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%4:Nat],'_+_[
+2 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%4:Nat],'_+_[
     '%2:Nat,'%3:NzNat],'false.Bool],'%1:MsgConf],'ff.FalseLit`{Bool`}])
-4 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%3:Nat,'%4:Nat],
-    '%2:Nat,'false.Bool],'%1:MsgConf],'tt.TrueLit`{Bool`}])
-6 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['_+_['@1:Nat,'@4:Nat],'@2:Nat,
-    'false.Bool],'@3:MsgConf],'_?=_['true.Bool,'_<=_['@2:Nat,'@1:Nat]]])
-16 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@2:Nat,'false.Bool],
-    '@4:MsgConf],'_?=_['true.Bool,'_<=_['_+_['@2:Nat,'@1:Nat],'_+_['@3:Nat,
-    '@1:Nat]]]])
-22 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['%2:Nat,'_+_['%2:Nat,
+4 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%3:Nat,
+    '%4:Nat],'%2:Nat,'false.Bool],'%1:MsgConf],'tt.TrueLit`{Bool`}])
+6 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['@1:Nat,'@4:Nat],
+    '@2:Nat,'false.Bool],'@3:MsgConf],'_?=_['true.Bool,'_<=_['@2:Nat,
+    '@1:Nat]]])
+16 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@2:Nat,
+    'false.Bool],'@4:MsgConf],'_?=_['true.Bool,'_<=_['_+_['@2:Nat,'@1:Nat],
+    '_+_['@3:Nat,'@1:Nat]]]])
+22 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['%2:Nat,'_+_['%2:Nat,
     '%4:NzNat],'true.Bool],'%1:MsgConf],'ff.FalseLit`{Bool`}])
-24 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%3:Nat],
+24 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%3:Nat],
     '%2:Nat,'true.Bool],'%1:MsgConf],'tt.TrueLit`{Bool`}])
-26 |-> state('_|_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@1:Nat,'true.Bool],
+26 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@1:Nat,'true.Bool],
     '@2:MsgConf],'_?=_['true.Bool,'_<=_['@1:Nat,'@3:Nat]]])
 | 27
 | 2 ; 4 ; 6 ; 16 ; 22 ; 24 ; 26
@@ -438,9 +444,9 @@ result Bool: true
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : states(1) <= states(2) .
 rewrites: 17
-result [Bool]: state('_|_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,
+result [Bool]: state('_st_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,
     'false.Bool],'MSGS:MsgConf],'_?=_['true.Bool,'_<=_['X:Nat,'N:Nat]]]) <=
-    state('_|_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'true.Bool],
+    state('_st_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'true.Bool],
     'MSGS:MsgConf],'C:Form`{Bool`}])
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : intersect(states(0), states(2))
@@ -453,17 +459,17 @@ rewrites: 2
 result Bool: true
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : implies?(pred(0), pred(1)) .
-rewrites: 29
+rewrites: 33
 result Bool: false
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : implies?(pred(1), pred(2)) .
-rewrites: 29
+rewrites: 33
 result Bool: false
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : invariant(states(0)) .
 rewrites: 266
-result [Bool]: state('_|_['_#_['<`bal:_pend:_overdraft:_>['@4:Nat,'@1:Nat,
-    'true.Bool],'@3:MsgConf],'@2:Form`{Bool`}]) <= state('_|_['_#_[
+result [Bool]: state('_st_['_#_['<`bal:_pend:_overdraft:_>['@4:Nat,'@1:Nat,
+    'true.Bool],'@3:MsgConf],'@2:Form`{Bool`}]) <= state('_st_['_#_[
     '<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],'MSGS:MsgConf],
     'C:Form`{Bool`}])
 ==========================================

--- a/tests/tools/lmc/bank-account.expected
+++ b/tests/tools/lmc/bank-account.expected
@@ -1,8 +1,8 @@
-Warning: "bank-account.maude", line 66 (mod BANK-ACCOUNT): variable m is used
+Warning: "bank-account.maude", line 73 (mod BANK-ACCOUNT): variable m is used
     before it is bound in rule:
 rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
     overdraft: false > # msgs [label overdraft] .
-Warning: "bank-account.maude", line 128 (mod BANK-ACCOUNT-CTOR): variable m is
+Warning: "bank-account.maude", line 142 (mod BANK-ACCOUNT-CTOR): variable m is
     used before it is bound in rule:
 rl < bal: n pend: x overdraft: false > # msgs => < bal: n + m pend: x
     overdraft: false > # msgs [narrowing label deposit] .
@@ -17,7 +17,7 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : #M .
 rewrites: 60
 result SModule: mod 'BANK-ACCOUNT-CTOR is
-  protecting 'BANK-ACCOUNT-DEFINEDOPS .
+  protecting 'FVP-BOOL-EQFORM .
   protecting 'FVP-NAT-PRED .
   sorts 'Account ; 'CState ; 'Msg ; 'MsgConf ; 'State ; 'StatePair .
   subsort 'Msg < 'MsgConf .
@@ -27,11 +27,15 @@ result SModule: mod 'BANK-ACCOUNT-CTOR is
   op '_st_ : 'State 'Form`{Bool`} -> 'CState [ctor prec(57)] .
   op '`[_`,_`,_`] : 'Bool 'State 'State -> 'State [frozen(1 2 3)] .
   op '`[_`,_`] : 'State 'State -> 'StatePair [ctor] .
+  op 'debts : 'MsgConf -> 'Nat [none] .
   op 'mt : nil -> 'MsgConf [ctor] .
   op 'withdraw : 'Nat -> 'Msg [ctor] .
   none
   eq '`[_`,_`,_`]['false.Bool,'s:State,'s':State] = 's':State [variant] .
   eq '`[_`,_`,_`]['true.Bool,'s:State,'s':State] = 's:State [variant] .
+  eq 'debts['mt.MsgConf] = '0.Nat [none] .
+  eq 'debts['_`,_['MSGS:MsgConf,'withdraw['N:Nat]]] = '_+_['N:Nat,'debts[
+    'MSGS:MsgConf]] [none] .
   rl '_st_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,'N2:Nat,'false.Bool],'_`,_[
     'M3:MsgConf,'withdraw['_+_['1.NzNat,'N1:Nat,'N4:Nat]]]],
     '###COND###:Form`{Bool`}] => '_st_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,
@@ -61,18 +65,19 @@ endm
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : #MC .
 rewrites: 3
-result SModule: mod 'BANK-ACCOUNT-DEFINEDOPS is
-  protecting 'BANK-ACCOUNT-CTOR .
-  protecting 'FVP-BOOL-EQFORM .
+result FModule: fmod 'FVP-BOOL-EQFORM is
+  protecting 'EQFORM-IMPL{'Bool} .
   sorts none .
   none
-  op 'debts : 'MsgConf -> 'Nat [none] .
   none
-  eq 'debts['mt.MsgConf] = '0.Nat [none] .
-  eq 'debts['_`,_['MSGS:MsgConf,'withdraw['N:Nat]]] = '_+_['N:Nat,'debts[
-    'MSGS:MsgConf]] [none] .
   none
-endm
+  eq '_!=_['false.Bool,'false.Bool] = 'ff.FalseLit`{Bool`} [none] .
+  eq '_!=_['true.Bool,'false.Bool] = 'tt.TrueLit`{Bool`} [none] .
+  eq '_!=_['true.Bool,'true.Bool] = 'ff.FalseLit`{Bool`} [none] .
+  eq '_?=_['false.Bool,'false.Bool] = 'tt.TrueLit`{Bool`} [none] .
+  eq '_?=_['true.Bool,'false.Bool] = 'ff.FalseLit`{Bool`} [none] .
+  eq '_?=_['true.Bool,'true.Bool] = 'tt.TrueLit`{Bool`} [none] .
+endfm
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : #MO .
 rewrites: 1
@@ -85,11 +90,15 @@ result SModule: mod 'BANK-ACCOUNT-CTOR is
   op '_`,_ : 'MsgConf 'MsgConf -> 'MsgConf [assoc comm ctor id('mt.MsgConf)] .
   op '`[_`,_`,_`] : 'Bool 'State 'State -> 'State [frozen(1 2 3)] .
   op '`[_`,_`] : 'State 'State -> 'StatePair [ctor] .
+  op 'debts : 'MsgConf -> 'Nat [none] .
   op 'mt : nil -> 'MsgConf [ctor] .
   op 'withdraw : 'Nat -> 'Msg [ctor] .
   none
   eq '`[_`,_`,_`]['false.Bool,'s:State,'s':State] = 's':State [variant] .
   eq '`[_`,_`,_`]['true.Bool,'s:State,'s':State] = 's:State [variant] .
+  eq 'debts['mt.MsgConf] = '0.Nat [none] .
+  eq 'debts['_`,_['MSGS:MsgConf,'withdraw['N:Nat]]] = '_+_['N:Nat,'debts[
+    'MSGS:MsgConf]] [none] .
   rl '_#_['<`bal:_pend:_overdraft:_>['N1:Nat,'N2:Nat,'false.Bool],'_`,_[
     'M3:MsgConf,'withdraw['_+_['1.NzNat,'N1:Nat,'N4:Nat]]]] => '_#_[
     '<`bal:_pend:_overdraft:_>['N1:Nat,'N2:Nat,'true.Bool],'M3:MsgConf] [
@@ -224,7 +233,7 @@ rewrites: 6
 result Bool: true
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : bfs(state(cinit(0))) .
-rewrites: 271
+rewrites: 151
 result FoldedLabeledGraph: (0 -[label('deposit, 
   'C:Form`{Bool`} <- '@4:Form`{Bool`} ; 
   'MSGS:MsgConf <- '@3:MsgConf ; 
@@ -233,15 +242,6 @@ result FoldedLabeledGraph: (0 -[label('deposit,
   'C:Form`{Bool`} <- '@4:Form`{Bool`} ; 
   'MSGS:MsgConf <- '@3:MsgConf ; 
   'N:Nat <- '_+_['@1:Nat,'@5:Nat] ; 
-  'X:Nat <- '@2:Nat)]
-0 -[label('deposit, 
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '@3:MsgConf ; 
-  'N:Nat <- '@1:Nat ; 
-  'X:Nat <- '@2:Nat)]-> 0[fold(
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '@3:MsgConf ; 
-  'N:Nat <- '_+_['@1:Nat,'@4:Nat] ; 
   'X:Nat <- '@2:Nat)]
 0 -[label('doWithdrawal1, 
   'C:Form`{Bool`} <- '@1:Form`{Bool`} ; 
@@ -252,15 +252,6 @@ result FoldedLabeledGraph: (0 -[label('deposit,
   'MSGS:MsgConf <- '@2:MsgConf ; 
   'N:Nat <- '@5:Nat ; 
   'X:Nat <- '0.Nat)]
-0 -[label('doWithdrawal1, 
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '_`,_['@1:MsgConf,'withdraw['_+_['@2:Nat,'@3:Nat]]] ; 
-  'N:Nat <- '_+_['@2:Nat,'@3:Nat,'@4:Nat] ; 
-  'X:Nat <- '@2:Nat)]-> 0[fold(
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '@1:MsgConf ; 
-  'N:Nat <- '@4:Nat ; 
-  'X:Nat <- '0.Nat)]
 0 -[label('doWithdrawal2, 
   'C:Form`{Bool`} <- '@1:Form`{Bool`} ; 
   'MSGS:MsgConf <- '_`,_['@5:MsgConf,'withdraw['@2:Nat]] ; 
@@ -270,15 +261,6 @@ result FoldedLabeledGraph: (0 -[label('deposit,
   'MSGS:MsgConf <- '@5:MsgConf ; 
   'N:Nat <- '@4:Nat ; 
   'X:Nat <- '@3:Nat)]
-0 -[label('doWithdrawal2, 
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '_`,_['@4:MsgConf,'withdraw['@1:Nat]] ; 
-  'N:Nat <- '_+_['@3:Nat,'@1:Nat] ; 
-  'X:Nat <- '_+_['@2:Nat,'@1:Nat])]-> 0[fold(
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '@4:MsgConf ; 
-  'N:Nat <- '@3:Nat ; 
-  'X:Nat <- '@2:Nat)]
 0 -[label('initWithdrawal, 
   'C:Form`{Bool`} <- '@2:Form`{Bool`} ; 
   'MSGS:MsgConf <- '@1:MsgConf ; 
@@ -288,51 +270,20 @@ result FoldedLabeledGraph: (0 -[label('deposit,
   'MSGS:MsgConf <- '_`,_['@1:MsgConf,'withdraw['@4:Nat]] ; 
   'N:Nat <- '_+_['@3:Nat,'@4:Nat,'@5:Nat] ; 
   'X:Nat <- '_+_['@4:Nat,'@5:Nat])]
-0 -[label('initWithdrawal, 
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '@1:MsgConf ; 
-  'N:Nat <- '_+_['@2:Nat,'@3:Nat,'@4:Nat] ; 
-  'X:Nat <- '@4:Nat)]-> 0[fold(
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '_`,_['@1:MsgConf,'withdraw['@3:Nat]] ; 
-  'N:Nat <- '_+_['@2:Nat,'@3:Nat,'@4:Nat] ; 
-  'X:Nat <- '_+_['@3:Nat,'@4:Nat])]
 0 -[label('overdraft, 
   'C:Form`{Bool`} <- '@2:Form`{Bool`} ; 
   'MSGS:MsgConf <- '_`,_['@3:MsgConf,'withdraw['_+_['1.NzNat,'@4:Nat,'@5:Nat]]]
     ; 
   'N:Nat <- '@4:Nat ; 
-  'X:Nat <- '@1:Nat)]-> 18
-0 -[label('overdraft, 
-  'C:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  'MSGS:MsgConf <- '_`,_['@2:MsgConf,'withdraw['_+_['1.NzNat,'@3:Nat,'@4:Nat]]]
-    ; 
-  'N:Nat <- '@3:Nat ; 
-  'X:Nat <- '@1:Nat)]-> 18[fold(
-  '@1:Nat <- '@1:Nat ; 
-  '@2:Form`{Bool`} <- '@5:Form`{Bool`} ; 
-  '@3:MsgConf <- '@2:MsgConf ; 
-  '@4:Nat <- '@3:Nat)])
+  'X:Nat <- '@1:Nat)]-> 10)
 | 0 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],
     'MSGS:MsgConf],'C:Form`{Bool`}])
-18 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@4:Nat,'@1:Nat,'true.Bool],
+10 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@4:Nat,'@1:Nat,'true.Bool],
     '@3:MsgConf],'@2:Form`{Bool`}])
-| 21
+| 11
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : bfs(state(cinit(1)), 1) .
-Warning: unsafe variable name %2:Nat in variant narrowing problem.
-Warning: unsafe variable name %2:Nat in variant narrowing problem.
-Warning: unsafe variable name @2:Nat in variant narrowing problem.
-Warning: unsafe variable name %4:Nat in variant narrowing problem.
-Warning: unsafe variable name @4:Nat in variant narrowing problem.
-Warning: unsafe variable name %2:Nat in variant narrowing problem.
-Warning: unsafe variable name %2:Nat in variant narrowing problem.
-Warning: unsafe variable name @2:Nat in variant narrowing problem.
-Warning: unsafe variable name @2:Nat in variant narrowing problem.
-Warning: unsafe variable name @2:Nat in variant narrowing problem.
-Warning: unsafe variable name %1:Nat in variant narrowing problem.
-Warning: unsafe variable name @3:Nat in variant narrowing problem.
-rewrites: 1338
+rewrites: 1104
 result FoldedLabeledGraph?: (0 -[label('deposit, 
   'MSGS:MsgConf <- '%1:MsgConf ; 
   'N:Nat <- '%2:Nat ; 
@@ -353,14 +304,6 @@ result FoldedLabeledGraph?: (0 -[label('deposit,
   '%2:Nat <- '0.Nat ; 
   '%3:Nat <- '%4:Nat ; 
   '%4:Nat <- '0.Nat)]
-0 -[label('doWithdrawal1, 
-  'MSGS:MsgConf <- '_`,_['@1:MsgConf,'withdraw['_+_['@2:Nat,'@3:Nat]]] ; 
-  'N:Nat <- '_+_['@2:Nat,'@3:Nat,'@4:Nat] ; 
-  'X:Nat <- '@2:Nat)]-> 4[fold(
-  '%1:MsgConf <- '@1:MsgConf ; 
-  '%2:Nat <- '0.Nat ; 
-  '%3:Nat <- '@4:Nat ; 
-  '%4:Nat <- '0.Nat)]
 0 -[label('doWithdrawal2, 
   'MSGS:MsgConf <- '_`,_['%4:MsgConf,'withdraw['%1:Nat]] ; 
   'N:Nat <- '_+_['%1:Nat,'%2:Nat] ; 
@@ -380,7 +323,7 @@ result FoldedLabeledGraph?: (0 -[label('deposit,
 0 -[label('doWithdrawal2, 
   'MSGS:MsgConf <- '_`,_['@4:MsgConf,'withdraw['@1:Nat]] ; 
   'N:Nat <- '_+_['@3:Nat,'@1:Nat] ; 
-  'X:Nat <- '_+_['@2:Nat,'@1:Nat])]-> 16
+  'X:Nat <- '_+_['@2:Nat,'@1:Nat])]-> 14
 0 -[label('initWithdrawal, 
   'MSGS:MsgConf <- '%2:MsgConf ; 
   'N:Nat <- '_+_['%1:Nat,'%3:Nat,'%4:Nat] ; 
@@ -389,29 +332,21 @@ result FoldedLabeledGraph?: (0 -[label('deposit,
   '%2:Nat <- '_+_['%1:Nat,'%3:Nat] ; 
   '%3:Nat <- '0.Nat ; 
   '%4:Nat <- '%4:Nat)]
-0 -[label('initWithdrawal, 
-  'MSGS:MsgConf <- '@1:MsgConf ; 
-  'N:Nat <- '_+_['@2:Nat,'@3:Nat,'@4:Nat] ; 
-  'X:Nat <- '@4:Nat)]-> 4[fold(
-  '%1:MsgConf <- '_`,_['@1:MsgConf,'withdraw['@3:Nat]] ; 
-  '%2:Nat <- '_+_['@3:Nat,'@4:Nat] ; 
-  '%3:Nat <- '0.Nat ; 
-  '%4:Nat <- '@2:Nat)]
 0 -[label('overdraft, 
   'MSGS:MsgConf <- '_`,_['%1:MsgConf,'withdraw['_+_['1.NzNat,'%2:Nat,'%3:Nat]]]
     ; 
   'N:Nat <- '%2:Nat ; 
-  'X:Nat <- '_+_['%2:Nat,'%4:NzNat])]-> 22
+  'X:Nat <- '_+_['%2:Nat,'%4:NzNat])]-> 18
 0 -[label('overdraft, 
   'MSGS:MsgConf <- '_`,_['%1:MsgConf,'withdraw['_+_['1.NzNat,'%2:Nat,'%3:Nat,
     '%4:Nat]]] ; 
   'N:Nat <- '_+_['%2:Nat,'%3:Nat] ; 
-  'X:Nat <- '%2:Nat)]-> 24
+  'X:Nat <- '%2:Nat)]-> 20
 0 -[label('overdraft, 
   'MSGS:MsgConf <- '_`,_['@2:MsgConf,'withdraw['_+_['1.NzNat,'@3:Nat,'@4:Nat]]]
     ; 
   'N:Nat <- '@3:Nat ; 
-  'X:Nat <- '@1:Nat)]-> 26)
+  'X:Nat <- '@1:Nat)]-> 22)
 | 0 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],
     'MSGS:MsgConf],'_?=_['true.Bool,'_<=_['X:Nat,'N:Nat]]])
 2 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%4:Nat],'_+_[
@@ -421,17 +356,17 @@ result FoldedLabeledGraph?: (0 -[label('deposit,
 6 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['@1:Nat,'@4:Nat],
     '@2:Nat,'false.Bool],'@3:MsgConf],'_?=_['true.Bool,'_<=_['@2:Nat,
     '@1:Nat]]])
-16 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@2:Nat,
+14 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@2:Nat,
     'false.Bool],'@4:MsgConf],'_?=_['true.Bool,'_<=_['_+_['@2:Nat,'@1:Nat],
     '_+_['@3:Nat,'@1:Nat]]]])
-22 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['%2:Nat,'_+_['%2:Nat,
+18 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['%2:Nat,'_+_['%2:Nat,
     '%4:NzNat],'true.Bool],'%1:MsgConf],'ff.FalseLit`{Bool`}])
-24 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%3:Nat],
+20 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['%2:Nat,'%3:Nat],
     '%2:Nat,'true.Bool],'%1:MsgConf],'tt.TrueLit`{Bool`}])
-26 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@1:Nat,'true.Bool],
+22 |-> state('_st_['_#_['<`bal:_pend:_overdraft:_>['@3:Nat,'@1:Nat,'true.Bool],
     '@2:MsgConf],'_?=_['true.Bool,'_<=_['@1:Nat,'@3:Nat]]])
-| 27
-| 2 ; 4 ; 6 ; 16 ; 22 ; 24 ; 26
+| 23
+| 2 ; 4 ; 6 ; 14 ; 18 ; 20 ; 22
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : state(pred(1)) <= state(pred(
     0)) .
@@ -459,15 +394,15 @@ rewrites: 2
 result Bool: true
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : implies?(pred(0), pred(1)) .
-rewrites: 33
+rewrites: 13
 result Bool: false
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : implies?(pred(1), pred(2)) .
-rewrites: 33
+rewrites: 13
 result Bool: false
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : invariant(states(0)) .
-rewrites: 266
+rewrites: 146
 result [Bool]: state('_st_['_#_['<`bal:_pend:_overdraft:_>['@4:Nat,'@1:Nat,
     'true.Bool],'@3:MsgConf],'@2:Form`{Bool`}]) <= state('_st_['_#_[
     '<`bal:_pend:_overdraft:_>['N:Nat,'X:Nat,'false.Bool],'MSGS:MsgConf],
@@ -478,6 +413,6 @@ rewrites: 27
 result Bool: true
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : invariant(states(0 ; 2)) .
-rewrites: 297
+rewrites: 178
 result Bool: true
 Bye.

--- a/tests/tools/lmc/bank-account.expected
+++ b/tests/tools/lmc/bank-account.expected
@@ -7,7 +7,7 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     SortDeclSet).
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : #M .
-rewrites: 60
+rewrites: 98
 result SModule: mod 'BANK-ACCOUNT-CTOR is
   protecting 'FVP-BOOL-EQFORM .
   protecting 'FVP-NAT-PRED .
@@ -36,8 +36,7 @@ result SModule: mod 'BANK-ACCOUNT-CTOR is
   rl '_st_['_#_['<`bal:_pend:_overdraft:_>['n:Nat,'x:Nat,'false.Bool],
     'msgs:MsgConf],'###COND###:Form`{Bool`}] => '_st_['_#_[
     '<`bal:_pend:_overdraft:_>['_+_['n:Nat,'m:Nat],'x:Nat,'false.Bool],
-    'msgs:MsgConf],'###COND###:Form`{Bool`}] [nonexec narrowing label(
-    'deposit)] .
+    'msgs:MsgConf],'###COND###:Form`{Bool`}] [narrowing label('deposit)] .
   rl '_st_['_#_['<`bal:_pend:_overdraft:_>['_+_['N1:Nat,'N3:Nat],'_+_['N3:Nat,
     'N4:Nat],'false.Bool],'_`,_['M2:MsgConf,'withdraw['N3:Nat]]],
     '###COND###:Form`{Bool`}] => '_st_['_#_['<`bal:_pend:_overdraft:_>['N1:Nat,
@@ -113,6 +112,10 @@ result SModule: mod 'BANK-ACCOUNT-CTOR is
 endm
 ==========================================
 reduce in BANK-ACCOUNT-CTOR-UNCONDITIONALIZED : wellFormed(#M) .
+Warning: <automatic>: variable m:Nat is used before it is bound in rule:
+rl < bal: n:Nat pend: x:Nat overdraft: false > # msgs:MsgConf st
+    ###COND###:Form{Bool} => < bal: n:Nat + m:Nat pend: x:Nat overdraft: false
+    > # msgs:MsgConf st ###COND###:Form{Bool} [narrowing label deposit] .
 rewrites: 2
 result Bool: true
 ==========================================

--- a/tests/tools/lmc/bank-account.maude
+++ b/tests/tools/lmc/bank-account.maude
@@ -9,6 +9,7 @@ load ../../../contrib/tools/meta/narrowing.maude
 
 mod BANK-ACCOUNT-INIT-STATES is
     extending FVP-CONDITIONAL-NARROWING-GRAPH + GRAPH-ANALYSIS .
+   protecting UNCONDITIONALIZE-FVP-BOOL .
 
     var N : Nat . vars NeNS NeNS' : NeNodeSet . vars T T' : Term .
 
@@ -73,12 +74,6 @@ mod BANK-ACCOUNT-CTOR-UNCONDITIONALIZED is
     vars C C' : Term .
 
     eq #tSort  = 'State .
-
-    eq #cModule   = 'BANK-ACCOUNT-DEFINEDOPS .
-    eq #cSort     = 'Form`{Bool`} .
-    eq #cTrue     = 'tt.TrueLit`{Bool`} .
-    eq #cFalse    = 'ff.FalseLit`{Bool`} .
-    eq #cConjunct = '_/\_ .
 
     eq #MO = upModule('BANK-ACCOUNT-CTOR, false) .
 

--- a/tests/tools/lmc/bank-account.maude
+++ b/tests/tools/lmc/bank-account.maude
@@ -8,7 +8,7 @@ load ../../../contrib/tools/meta/narrowing.maude
 --- =============================
 
 mod BANK-ACCOUNT-INIT-STATES is
-    extending FVP-NARROWING-MODULO-T-GRAPH .
+    extending FVP-CONDITIONAL-NARROWING-GRAPH + GRAPH-ANALYSIS .
 
     var N : Nat . vars NeNS NeNS' : NeNodeSet . vars T T' : Term .
 
@@ -42,14 +42,14 @@ mod BANK-ACCOUNT-INIT-STATES is
 
     op cinit : Nat -> [Term] .
     --------------------------
-    eq cinit(0) = '_|_[init(0), pred(0)] .
-    eq cinit(1) = '_|_[init(0), pred(1)] .
-    eq cinit(2) = '_|_[init(1), pred(0)] .
-    eq cinit(3) = '_|_[init(1), pred(1)] .
-    eq cinit(4) = '_|_[init(2), pred(2)] .
-    eq cinit(5) = '_|_[init(3), pred(3)] .
-    eq cinit(6) = '_|_[init(4), pred(5)] .
-    eq cinit(7) = '_|_[init(5), pred(6)] .
+    eq cinit(0) = '_st_[init(0), pred(0)] .
+    eq cinit(1) = '_st_[init(0), pred(1)] .
+    eq cinit(2) = '_st_[init(1), pred(0)] .
+    eq cinit(3) = '_st_[init(1), pred(1)] .
+    eq cinit(4) = '_st_[init(2), pred(2)] .
+    eq cinit(5) = '_st_[init(3), pred(3)] .
+    eq cinit(6) = '_st_[init(4), pred(5)] .
+    eq cinit(7) = '_st_[init(5), pred(6)] .
 
     op sub : Nat -> [Substitution] .
     --------------------------------
@@ -69,16 +69,21 @@ endm
 
 mod BANK-ACCOUNT-CTOR-UNCONDITIONALIZED is
     extending BANK-ACCOUNT-INIT-STATES .
-    extending GRAPH-ANALYSIS .
 
     vars C C' : Term .
 
-    eq #T  = 'State .
-    eq #C  = 'Form`{Bool`} .
-    eq #ST = '_|_   .
+    eq #tSort  = 'State .
 
-    eq #MC = upModule('BANK-ACCOUNT-DEFINEDOPS, false) .
-    eq #MO = upModule('BANK-ACCOUNT-CTOR,       false) .
+    eq #cModule   = 'BANK-ACCOUNT-DEFINEDOPS .
+    eq #cSort     = 'Form`{Bool`} .
+    eq #cTrue     = 'tt.TrueLit`{Bool`} .
+    eq #cFalse    = 'ff.FalseLit`{Bool`} .
+    eq #cConjunct = '_/\_ .
+
+    eq #MO = upModule('BANK-ACCOUNT-CTOR, false) .
+
+    op #MC : -> Module .
+    eq #MC = upModule(#cModule, false) .
 
     eq implies?(C, C)  = true .
    ceq implies?(C, C') = true  if {'false.Bool, 'Bool} := metaReduce(#MC, '_=>_[C, C']) .

--- a/tests/tools/meta/mtransform.expected
+++ b/tests/tools/meta/mtransform.expected
@@ -186,4 +186,219 @@ reduce in UNCONDITIONALIZE : wellFormed(fromTemplate('QLOCK-STATE,
     stripConditions(asTemplate(upModule('QLOCK-STATE, true))))) .
 rewrites: 8
 result Bool: true
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 6 out of 40 sort tuples. First such tuple is (Type).
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 1 out of 26 sort tuples. First such tuple is (NullDeclSet).
+Warning: ctor declarations for associative operator __ are conflict on 138 out
+    of 17576 sort triples. First such triple is (ModuleDeclSet, SortDeclSet,
+    SortDeclSet).
+==========================================
+reduce in DIJKSTRA-UNCONDITIONALIZED : M .
+rewrites: 141
+result SModule: mod 'DIJKSTRA is
+  protecting 'DIJKSTRA-DATA .
+  protecting 'FVP-BOOL-EQFORM .
+  sorts 'CState ; 'Conf ; 'State .
+  none
+  op '<_> : 'Conf -> 'State [ctor] .
+  op '_st_ : 'State 'Form`{Bool`} -> 'CState [ctor prec(57)] .
+  op '_|_ : 'Proc 'ProcSet -> 'Conf [ctor] .
+  op '`[_`] : 'Conf -> 'State [ctor] .
+  none
+  none
+  rl '_st_['<_>['_|_['P:Proc,'PS:ProcSet]],'###COND###:Form`{Bool`}] => '_st_[
+    '`[_`]['_|_['P:Proc,'PS:ProcSet]],'###COND###:Form`{Bool`}] [narrowing
+    label('stop)] .
+  rl '_st_['<_>['_|_['P:Proc,'__['`{0`,try`}.WProc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['P:Proc,'__['`{1`,try`}.WProc,
+    'PS:ProcSet]]],'###COND###:Form`{Bool`}] [narrowing label('start1)] .
+  rl '_st_['<_>['_|_['P:Proc,'__['`{1`,upf`}.WProc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['P:Proc,'__['`{2`,chf`}.2Proc,
+    'PS:ProcSet]]],'###COND###:Form`{Bool`}] [narrowing label('set-flag1)] .
+  rl '_st_['<_>['_|_['P:Proc,'__['`{1`,upt`}.WProc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['`{1`,upf`}.WProc,'__['P:Proc,
+    'PS:ProcSet]]],'###COND###:Form`{Bool`}] [narrowing label('set-turn1)] .
+  rl '_st_['<_>['_|_['P:Proc,'__['`{2`,chf`}.2Proc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['P:Proc,'__['`{2`,crt`}.CProc,
+    'PS:ProcSet]]],'_/\_['###COND###:Form`{Bool`},'_?=_['safe?['__['P:Proc,
+    'PS:ProcSet]],'true.Bool]]] [narrowing label('go-crit1)] .
+  rl '_st_['<_>['_|_['P:Proc,'__['`{2`,chf`}.2Proc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['P:Proc,'__['`{2`,ext`}.2Proc,
+    'PS:ProcSet]]],'_/\_['###COND###:Form`{Bool`},'_?=_['safe?['__['P:Proc,
+    'PS:ProcSet]],'false.Bool]]] [narrowing label('fail-crit1)] .
+  rl '_st_['<_>['_|_['P:Proc,'__['`{2`,crt`}.CProc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['P:Proc,'__['`{2`,ext`}.2Proc,
+    'PS:ProcSet]]],'###COND###:Form`{Bool`}] [narrowing label('done-crit1)] .
+  rl '_st_['<_>['_|_['P:Proc,'__['`{2`,ext`}.2Proc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['P:Proc,'__['`{0`,try`}.WProc,
+    'PS:ProcSet]]],'###COND###:Form`{Bool`}] [narrowing label('exit-crit1)] .
+  rl '_st_['<_>['_|_['`{0`,try`}.WProc,'PS:ProcSet]],'###COND###:Form`{Bool`}]
+    => '_st_['<_>['_|_['`{1`,try`}.WProc,'PS:ProcSet]],
+    '###COND###:Form`{Bool`}] [narrowing label('start2)] .
+  rl '_st_['<_>['_|_['`{0`,try`}.WProc,'__['`{1`,try`}.WProc,'PS:ProcSet]]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['`{0`,try`}.WProc,'__[
+    '`{1`,upt`}.WProc,'PS:ProcSet]]],'###COND###:Form`{Bool`}] [narrowing
+    label('chk-turn1)] .
+  rl '_st_['<_>['_|_['`{1`,try`}.WProc,'PS:ProcSet]],'###COND###:Form`{Bool`}]
+    => '_st_['<_>['_|_['`{1`,upf`}.WProc,'PS:ProcSet]],
+    '###COND###:Form`{Bool`}] [narrowing label('chk-turn2)] .
+  rl '_st_['<_>['_|_['`{1`,upf`}.WProc,'PS:ProcSet]],'###COND###:Form`{Bool`}]
+    => '_st_['<_>['_|_['`{2`,chf`}.2Proc,'PS:ProcSet]],
+    '###COND###:Form`{Bool`}] [narrowing label('set-flag2)] .
+  rl '_st_['<_>['_|_['`{2`,chf`}.2Proc,'2PS:2ProcSet]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['`{2`,ext`}.2Proc,
+    '2PS:2ProcSet]],'###COND###:Form`{Bool`}] [narrowing label('fail-crit2)] .
+  rl '_st_['<_>['_|_['`{2`,chf`}.2Proc,'WPS:WProcSet]],
+    '###COND###:Form`{Bool`}] => '_st_['<_>['_|_['`{2`,crt`}.CProc,
+    'WPS:WProcSet]],'###COND###:Form`{Bool`}] [narrowing label('go-crit2)] .
+  rl '_st_['<_>['_|_['`{2`,crt`}.CProc,'PS:ProcSet]],'###COND###:Form`{Bool`}]
+    => '_st_['<_>['_|_['`{2`,ext`}.2Proc,'PS:ProcSet]],
+    '###COND###:Form`{Bool`}] [narrowing label('done-crit2)] .
+  rl '_st_['<_>['_|_['`{2`,ext`}.2Proc,'PS:ProcSet]],'###COND###:Form`{Bool`}]
+    => '_st_['<_>['_|_['`{0`,try`}.WProc,'PS:ProcSet]],
+    '###COND###:Form`{Bool`}] [narrowing label('exit-crit2)] .
+endm
+==========================================
+reduce in DIJKSTRA-UNCONDITIONALIZED : wellFormed(M) .
+rewrites: 2
+result Bool: true
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 6 out of 40 sort tuples. First such tuple is (Type).
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 1 out of 26 sort tuples. First such tuple is (NullDeclSet).
+Warning: ctor declarations for associative operator __ are conflict on 138 out
+    of 17576 sort triples. First such triple is (ModuleDeclSet, SortDeclSet,
+    SortDeclSet).
+==========================================
+reduce in FT-COMM-UNCONDITIONALIZED : M .
+rewrites: 99
+result SModule: mod 'FT-COMM is
+  protecting 'FT-COMM-DATA .
+  protecting 'FVP-BOOL-EQFORM .
+  sorts 'CState ; 'State .
+  none
+  op '_st_ : 'State 'Form`{Bool`} -> 'CState [ctor prec(57)] .
+  op '`[_::_|_|_|_::_`] : 'Nat 'ListNat 'MaybeNat 'MaybePairNat 'ListNat 'Nat
+    -> 'State [ctor] .
+  none
+  none
+  rl '_st_['`[_::_|_|_|_::_`]['n:Nat,'l1:ListNat,'k:Nat,'pa?:MaybePairNat,
+    'l2:ListNat,'m:Nat],'###COND###:Form`{Bool`}] => '_st_['`[_::_|_|_|_::_`][
+    'n:Nat,'l1:ListNat,'null.MaybeNat,'pa?:MaybePairNat,'l2:ListNat,'m:Nat],
+    '###COND###:Form`{Bool`}] [narrowing label('drop-ack)] .
+  rl '_st_['`[_::_|_|_|_::_`]['n:Nat,'l1:ListNat,'n?:MaybeNat,'pa:PairNat,
+    'l2:ListNat,'m:Nat],'###COND###:Form`{Bool`}] => '_st_['`[_::_|_|_|_::_`][
+    'n:Nat,'l1:ListNat,'n?:MaybeNat,'nullp.MaybePairNat,'l2:ListNat,'m:Nat],
+    '###COND###:Form`{Bool`}] [narrowing label('drop-snd)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'l:NeListNat,'n?:MaybeNat,'`[_`,_`][
+    'n:Nat,'q:NzNat],'l':NeListNat,'q:NzNat],'###COND###:Form`{Bool`}] =>
+    '_st_['`[_::_|_|_|_::_`]['p:NzNat,'l:NeListNat,'q:NzNat,
+    'nullp.MaybePairNat,'l':NeListNat,'q:NzNat],'###COND###:Form`{Bool`}] [
+    narrowing label('resend-ack)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'l:NeListNat,'n?:MaybeNat,'`[_`,_`][
+    'n:Nat,'_+_['1.NzNat,'m:Nat]],'l':NeListNat,'m:Nat],
+    '###COND###:Form`{Bool`}] => '_st_['`[_::_|_|_|_::_`]['p:NzNat,
+    'l:NeListNat,'_+_['1.NzNat,'m:Nat],'nullp.MaybePairNat,'__['l':NeListNat,
+    'n:Nat],'_+_['1.NzNat,'m:Nat]],'###COND###:Form`{Bool`}] [narrowing label(
+    'rec-+)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'l:NeListNat,'n?:MaybeNat,'`[_`,_`][
+    'n:Nat,'_+_['1.NzNat,'m:Nat]],'nil.ListNat,'m:Nat],
+    '###COND###:Form`{Bool`}] => '_st_['`[_::_|_|_|_::_`]['p:NzNat,
+    'l:NeListNat,'_+_['1.NzNat,'m:Nat],'nullp.MaybePairNat,'n:Nat,'_+_[
+    '1.NzNat,'m:Nat]],'###COND###:Form`{Bool`}] [narrowing label('rec-1)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'n:Nat,'n?:MaybeNat,'nullp.MaybePairNat,
+    'l1:ListNat,'m:Nat],'###COND###:Form`{Bool`}] => '_st_['`[_::_|_|_|_::_`][
+    'p:NzNat,'n:Nat,'null.MaybeNat,'`[_`,_`]['n:Nat,'p:NzNat],'l1:ListNat,
+    'm:Nat],'_/\_['###COND###:Form`{Bool`},'_?=_['_=/=_['n?:MaybeNat,'p:NzNat],
+    'true.Bool]]] [narrowing label('resend-1)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'n:Nat,'p:NzNat,'pa?:MaybePairNat,
+    'l:NeListNat,'q:NzNat],'###COND###:Form`{Bool`}] => '_st_[
+    '`[_::_|_|_|_::_`]['p:NzNat,'nil.ListNat,'null.MaybeNat,
+    'nullp.MaybePairNat,'l:NeListNat,'q:NzNat],'###COND###:Form`{Bool`}] [
+    narrowing label('rec-ack-1)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'__['n:Nat,'l:NeListNat],'n?:MaybeNat,
+    'nullp.MaybePairNat,'l1:ListNat,'m:Nat],'###COND###:Form`{Bool`}] => '_st_[
+    '`[_::_|_|_|_::_`]['p:NzNat,'__['n:Nat,'l:NeListNat],'null.MaybeNat,
+    '`[_`,_`]['n:Nat,'p:NzNat],'l1:ListNat,'m:Nat],'_/\_[
+    '###COND###:Form`{Bool`},'_?=_['_=/=_['n?:MaybeNat,'p:NzNat],'true.Bool]]]
+    [narrowing label('resend-+)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'__['n:Nat,'m:Nat],'p:NzNat,
+    'pa?:MaybePairNat,'l:NeListNat,'q:NzNat],'###COND###:Form`{Bool`}] =>
+    '_st_['`[_::_|_|_|_::_`]['_+_['1.NzNat,'p:NzNat],'m:Nat,'null.MaybeNat,
+    '`[_`,_`]['m:Nat,'_+_['1.NzNat,'p:NzNat]],'l:NeListNat,'q:NzNat],
+    '###COND###:Form`{Bool`}] [narrowing label('rec-ack-2)] .
+  rl '_st_['`[_::_|_|_|_::_`]['p:NzNat,'__['n:Nat,'m:Nat,'l':NeListNat],
+    'p:NzNat,'pa?:MaybePairNat,'l:NeListNat,'q:NzNat],'###COND###:Form`{Bool`}]
+    => '_st_['`[_::_|_|_|_::_`]['_+_['1.NzNat,'p:NzNat],'__['m:Nat,
+    'l':NeListNat],'null.MaybeNat,'`[_`,_`]['m:Nat,'_+_['1.NzNat,'p:NzNat]],
+    'l:NeListNat,'q:NzNat],'###COND###:Form`{Bool`}] [narrowing label(
+    'rec-ack-+)] .
+endm
+==========================================
+reduce in FT-COMM-UNCONDITIONALIZED : wellFormed(M) .
+rewrites: 2
+result Bool: true
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 6 out of 40 sort tuples. First such tuple is (Type).
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 1 out of 26 sort tuples. First such tuple is (NullDeclSet).
+Warning: ctor declarations for associative operator __ are conflict on 138 out
+    of 17576 sort triples. First such triple is (ModuleDeclSet, SortDeclSet,
+    SortDeclSet).
+==========================================
+reduce in THERMOSTAT-UNCONDITIONALIZED-TEST : M .
+rewrites: 93
+result SModule: mod 'THERMOSTAT is
+  protecting 'FVP-BOOL-EQFORM .
+  protecting 'FVP-NAT-PRED .
+  protecting 'FVP-NUMBERS .
+  sorts 'CConf ; 'Conf ; 'DelayMode ; 'InMode ; 'Mode .
+  subsort 'DelayMode < 'Mode .
+  subsort 'InMode < 'Mode .
+  op '<_`,_`,_> : 'Nat 'Nat 'Mode -> 'Conf [ctor] .
+  op '_st_ : 'Conf 'Form`{Bool`} -> 'CConf [ctor prec(57)] .
+  op '`{_`,_`,_`} : 'Nat 'Nat 'Mode -> 'Conf [ctor] .
+  op 'bound : nil -> 'Nat [none] .
+  op 'delay : 'InMode -> 'DelayMode [ctor] .
+  op 'heat-rate : 'Mode 'Nat -> 'Nat [none] .
+  op 'max : nil -> 'Nat [none] .
+  op 'min : nil -> 'Nat [none] .
+  op 'off : nil -> 'InMode [ctor] .
+  op 'on : nil -> 'InMode [ctor] .
+  op 'time-until : 'InMode -> 'Nat [none] .
+  none
+  none
+  rl '_st_['<_`,_`,_>['TIME:Nat,'TMP:Nat,'MODE:Mode],'###COND###:Form`{Bool`}]
+    => '_st_['`{_`,_`,_`}['TIME:Nat,'heat-rate['MODE:Mode,'TMP:Nat],
+    'MODE:Mode],'###COND###:Form`{Bool`}] [narrowing label('tick)] .
+  rl '_st_['`{_`,_`,_`}['0.Nat,'TMP:Nat,'delay['IM:InMode]],
+    '###COND###:Form`{Bool`}] => '_st_['<_`,_`,_>['0.Nat,'TMP:Nat,'IM:InMode],
+    '###COND###:Form`{Bool`}] [narrowing label('delay-over)] .
+  rl '_st_['`{_`,_`,_`}['TIME:Nat,'TMP:Nat,'off.InMode],
+    '###COND###:Form`{Bool`}] => '_st_['<_`,_`,_>['TIME:Nat,'TMP:Nat,
+    'off.InMode],'_/\_['###COND###:Form`{Bool`},'_?=_['_<_['TMP:Nat,'_+_[
+    'min.Nat,'bound.Nat]],'false.Bool]]] [narrowing label('inmode-off)] .
+  rl '_st_['`{_`,_`,_`}['TIME:Nat,'TMP:Nat,'off.InMode],
+    '###COND###:Form`{Bool`}] => '_st_['<_`,_`,_>['time-until['on.InMode],
+    'TMP:Nat,'delay['on.InMode]],'_/\_['###COND###:Form`{Bool`},'_?=_['_<_[
+    'TMP:Nat,'_+_['min.Nat,'bound.Nat]],'true.Bool]]] [narrowing label(
+    'turning-on)] .
+  rl '_st_['`{_`,_`,_`}['TIME:Nat,'TMP:Nat,'on.InMode],
+    '###COND###:Form`{Bool`}] => '_st_['<_`,_`,_>['TIME:Nat,'TMP:Nat,
+    'on.InMode],'_/\_['###COND###:Form`{Bool`},'_?=_['_<_['max.Nat,'_+_[
+    'bound.Nat,'TMP:Nat]],'false.Bool]]] [narrowing label('inmode-on)] .
+  rl '_st_['`{_`,_`,_`}['TIME:Nat,'TMP:Nat,'on.InMode],
+    '###COND###:Form`{Bool`}] => '_st_['<_`,_`,_>['time-until['off.InMode],
+    'TMP:Nat,'delay['off.InMode]],'_/\_['###COND###:Form`{Bool`},'_?=_['_<_[
+    'max.Nat,'_+_['bound.Nat,'TMP:Nat]],'true.Bool]]] [narrowing label(
+    'turning-off)] .
+  rl '_st_['`{_`,_`,_`}['_+_['1.NzNat,'TIME:Nat],'TMP:Nat,'DM:DelayMode],
+    '###COND###:Form`{Bool`}] => '_st_['<_`,_`,_>['TIME:Nat,'TMP:Nat,
+    'DM:DelayMode],'###COND###:Form`{Bool`}] [narrowing label('delaying)] .
+endm
+==========================================
+reduce in THERMOSTAT-UNCONDITIONALIZED-TEST : wellFormed(M) .
+rewrites: 2
+result Bool: true
 Bye.

--- a/tests/tools/meta/mtransform.expected
+++ b/tests/tools/meta/mtransform.expected
@@ -195,7 +195,7 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     SortDeclSet).
 ==========================================
 reduce in DIJKSTRA-UNCONDITIONALIZED : M .
-rewrites: 141
+rewrites: 205
 result SModule: mod 'DIJKSTRA is
   protecting 'DIJKSTRA-DATA .
   protecting 'FVP-BOOL-EQFORM .
@@ -272,7 +272,7 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     SortDeclSet).
 ==========================================
 reduce in FT-COMM-UNCONDITIONALIZED : M .
-rewrites: 99
+rewrites: 139
 result SModule: mod 'FT-COMM is
   protecting 'FT-COMM-DATA .
   protecting 'FVP-BOOL-EQFORM .
@@ -348,7 +348,7 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     SortDeclSet).
 ==========================================
 reduce in THERMOSTAT-UNCONDITIONALIZED-TEST : M .
-rewrites: 93
+rewrites: 121
 result SModule: mod 'THERMOSTAT is
   protecting 'FVP-BOOL-EQFORM .
   protecting 'FVP-NAT-PRED .

--- a/tests/tools/meta/mtransform.maude
+++ b/tests/tools/meta/mtransform.maude
@@ -1,8 +1,8 @@
-
-
 load ../../../contrib/systems/dijkstra.maude
 load ../../../contrib/systems/bakery.maude
 load ../../../contrib/systems/qlock.maude
+load ../../../contrib/systems/oc.maude
+load ../../../contrib/systems/thermostat.maude
 load ../../../contrib/tools/meta/mtransform.maude
 
 --- Module SUBTHEORY-ABSTRACTION
@@ -34,3 +34,42 @@ reduce stripConditions(asTemplate(upModule('QLOCK-STATE , true))) .
 reduce wellFormed(fromTemplate('DIJKSTRA    , stripConditions(asTemplate(upModule('DIJKSTRA    , true))))) .
 reduce wellFormed(fromTemplate('BAKERY-FVP  , stripConditions(asTemplate(upModule('BAKERY-FVP  , true))))) .
 reduce wellFormed(fromTemplate('QLOCK-STATE , stripConditions(asTemplate(upModule('QLOCK-STATE , true))))) .
+
+fmod DIJKSTRA-UNCONDITIONALIZED is
+   protecting UNCONDITIONALIZE-FVP-BOOL .
+
+    eq #tSort = 'State .
+
+    op M : -> Module [memo] .
+    -------------------------
+    eq M = unconditionalize(upModule('DIJKSTRA, false)) .
+endfm
+
+reduce M .
+reduce wellFormed(M) .
+
+fmod FT-COMM-UNCONDITIONALIZED is
+   protecting UNCONDITIONALIZE-FVP-BOOL .
+
+    eq #tSort = 'State .
+
+    op M : -> Module [memo] .
+    -------------------------
+    eq M = unconditionalize(upModule('FT-COMM, false)) .
+endfm
+
+reduce M .
+reduce wellFormed(M) .
+
+fmod THERMOSTAT-UNCONDITIONALIZED-TEST is
+   protecting UNCONDITIONALIZE-FVP-BOOL .
+
+    eq #tSort = 'Conf .
+
+    op M : -> Module [memo] .
+    -------------------------
+    eq M = unconditionalize(upModule('THERMOSTAT, false)) .
+endfm
+
+reduce M .
+reduce wellFormed(M) .

--- a/tests/tools/meta/narrowing.expected
+++ b/tests/tools/meta/narrowing.expected
@@ -105,17 +105,17 @@ result Variable: '#1:Nat
 ==========================================
 reduce in NAT-HARNESS : getTerms(variants(##m##, init(3))) .
 rewrites: 22
-result NeTermList: 'false.Bool,'true.Bool,'_<_['#1:Nat,'#2:NzNat]
+result NeTermSet: 'false.Bool | 'true.Bool | ('_<_['#1:Nat,'#2:NzNat])
 ==========================================
 reduce in NAT-HARNESS : getTerms(variants(##m##, init(4))) .
-rewrites: 27
-result NeTermList: 'false.Bool,'true.Bool,'true.Bool,'_<_['#1:Nat,'_+_[
-    '1.NzNat,'#2:Nat]]
+rewrites: 28
+result NeTermSet: 'false.Bool | 'true.Bool | ('_<_['#1:Nat,'_+_['1.NzNat,
+    '#2:Nat]])
 ==========================================
 reduce in NAT-HARNESS : getTerms(variants(##m##, init(5))) .
-rewrites: 27
-result NeTermList: 'false.Bool,'true.Bool,'true.Bool,'_<_['#1:NzNat,'_+_[
-    '1.NzNat,'#2:Nat]]
+rewrites: 28
+result NeTermSet: 'false.Bool | 'true.Bool | ('_<_['#1:NzNat,'_+_['1.NzNat,
+    '#2:Nat]])
 ==========================================
 reduce in NAT-HARNESS : getTerms(variants(##m##, init(6))) .
 rewrites: 12

--- a/tests/tools/meta/purification.expected
+++ b/tests/tools/meta/purification.expected
@@ -57,6 +57,37 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     of 17576 sort triples. First such triple is (ModuleDeclSet, SortDeclSet,
     SortDeclSet).
 ==========================================
+reduce in TEST-PURIFY : moduleIntersect(asTemplate(natMultMod), asTemplate(
+    natMultMod)) == asTemplate(natMultMod) .
+rewrites: 26
+result Bool: true
+==========================================
+reduce in TEST-PURIFY : moduleIntersect(asTemplate(natOrderMod), asTemplate(
+    natOrderMod)) == asTemplate(natOrderMod) .
+rewrites: 30
+result Bool: true
+==========================================
+reduce in TEST-PURIFY : moduleIntersect(asTemplate(natListMod), asTemplate(
+    natListMod)) == asTemplate(natListMod) .
+rewrites: 16
+result Bool: true
+==========================================
+reduce in TEST-PURIFY : moduleIntersect(asTemplate(natMultMod), asTemplate(
+    natOrderMod)) == asTemplate(upModule('FVP-NAT, true)) .
+rewrites: 33
+result Bool: true
+==========================================
+reduce in TEST-PURIFY : moduleIntersect(asTemplate(natMultMod), asTemplate(
+    natListMod)) == asTemplate(upModule('FVP-NAT-SORT, true)) .
+rewrites: 18
+result Bool: true
+==========================================
+reduce in TEST-PURIFY : moduleIntersect(asTemplate(natOrderMod), asTemplate(
+    natListMod)) == asTemplate(upModule('FVP-BOOL-CTOR, true))
+asTemplate(upModule('FVP-NAT-SORT, true)) .
+rewrites: 26
+result Bool: true
+==========================================
 reduce in TEST-PURIFY : 'Foo inS moduleIntersect(asTemplate(natOrderMod),
     asTemplate(natListMod)) == false .
 rewrites: 21

--- a/tests/tools/meta/purification.maude
+++ b/tests/tools/meta/purification.maude
@@ -86,6 +86,13 @@ endfm
 --- Function `moduleIntersect`
 --- --------------------------
 
+reduce moduleIntersect(asTemplate(natMultMod),  asTemplate(natMultMod))  == asTemplate(natMultMod) .
+reduce moduleIntersect(asTemplate(natOrderMod), asTemplate(natOrderMod)) == asTemplate(natOrderMod) .
+reduce moduleIntersect(asTemplate(natListMod),  asTemplate(natListMod))  == asTemplate(natListMod) .
+reduce moduleIntersect(asTemplate(natMultMod),  asTemplate(natOrderMod)) == asTemplate(upModule('FVP-NAT, true)) .
+reduce moduleIntersect(asTemplate(natMultMod),  asTemplate(natListMod))  == asTemplate(upModule('FVP-NAT-SORT, true)) .
+reduce moduleIntersect(asTemplate(natOrderMod), asTemplate(natListMod))  == asTemplate(upModule('FVP-NAT-SORT, true)) asTemplate(upModule('FVP-BOOL-CTOR, true)) .
+
 reduce 'Foo     inS moduleIntersect(asTemplate(natOrderMod), asTemplate(natListMod)) == false .
 reduce 'NatList inS moduleIntersect(asTemplate(natOrderMod), asTemplate(natListMod)) == false .
 

--- a/tests/tools/meta/terms.expected
+++ b/tests/tools/meta/terms.expected
@@ -1,1 +1,27 @@
+==========================================
+reduce in SUBSTITUTION-SET : isRenaming(none) .
+rewrites: 1
+result Bool: true
+==========================================
+reduce in SUBSTITUTION-SET : isRenaming(
+  'T:Foo <- 'B:Bar) .
+rewrites: 4
+result Bool: true
+==========================================
+reduce in SUBSTITUTION-SET : isRenaming(
+  'T:Foo <- 'B:Bar ; 
+  'X:Foo <- 'B:Bar) .
+rewrites: 7
+result Bool: true
+==========================================
+reduce in SUBSTITUTION-SET : isRenaming(
+  'T:Foo <- 'B:Bar ; 
+  'X:Foo <- 'bar.Bar) .
+rewrites: 6
+result Bool: false
+==========================================
+reduce in SUBSTITUTION-SET : isRenaming(
+  'T:Foo <- 'bar.Bar) .
+rewrites: 3
+result Bool: false
 Bye.

--- a/tests/tools/meta/terms.maude
+++ b/tests/tools/meta/terms.maude
@@ -1,1 +1,9 @@
 load ../../../contrib/tools/meta/terms.maude
+
+select SUBSTITUTION-SET .
+
+reduce isRenaming(none) .
+reduce isRenaming('T:Foo <- 'B:Bar) .
+reduce isRenaming('T:Foo <- 'B:Bar ; 'X:Foo <- 'B:Bar) .
+reduce isRenaming('T:Foo <- 'B:Bar ; 'X:Foo <- 'bar.Bar) .
+reduce isRenaming('T:Foo <- 'bar.Bar) .


### PR DESCRIPTION
This adds the `unconditionalize` operation, a parameterized operation for reducing a conditional rewrite theory to an unconditional one. Right now only rules are unconditionalized, but it could be done for equations as well.