### PR TITLE
Port tools from foform tools to eqform

### DIFF
--- a/build
+++ b/build
@@ -119,6 +119,7 @@ build_test() {
 }
 
 build_test_load() {
+    build_tangle
     (   cd "$contrib_dir"
         make test-load "$@"
     )

--- a/contrib/tools/fvp.md/numbers.md
+++ b/contrib/tools/fvp.md/numbers.md
@@ -147,12 +147,15 @@ fmod FVP-NAT-PRED is
    protecting FVP-NAT .
    protecting FVP-BOOL-CTOR .
 
-    vars   N N' :   Nat .
-    var  NzN    : NzNat .
+    vars   N   N' :   Nat .
+    vars NzN NzN' : NzNat .
 
     op _<_  : Nat Nat -> Bool .
     op _<=_ : Nat Nat -> Bool .
     ---------------------------
+    eq 1 + NzN <  1 + NzN' = NzN <  NzN' .
+    eq 1 + NzN <= 1 + NzN' = NzN <= NzN' .
+
     eq N <  N + NzN  = true [variant] .
     eq N <= N +   N' = true [variant] .
 

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -566,6 +566,17 @@ fmod EQFORM-SET is
   op (_|_) : EqFormNeSet     EqFormSet     -> EqFormNeSet    [ctor ditto] .
   op (_|_) : NormFormNeSet   NormFormSet   -> NormFormNeSet  [ctor ditto] .
   op (_|_) : FormNeSet       FormSet       -> FormNeSet      [ctor ditto] .
+
+  var S : Substitution . var NeSS : NeSubstitutionSet . var SS : SubstitutionSet .
+  var F : Form         . var FNeS : FormNeSet         . var FS : FormSet .
+
+  op _<<_ : FormSet SubstitutionSet -> [FormSet] .
+  ------------------------------------------------
+  eq mtFormSet  << SS = mtFormSet .
+  eq (F | FNeS) << SS = (F << SS) | (FNeS << SS) .
+
+  eq FS << .SubstitutionSet = mtFormSet .
+  eq FS << (S | NeSS)       = (FS << S) | (FS << NeSS) .
 endfm
 ```
 

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -203,14 +203,27 @@ fmod EQFORM-IMPL{X :: TRIV} is
   op _\/_ : Form{X}           Form{X}           -> Form{X}          [ditto] .
   ---------------------------------------------------------------------------
 
+  vars X X' : X$Elt .
   var EqL : EqLit{X} .
   vars F F' : Form{X} .
+
+  eq ~ tt = ff .
+  eq ~ ff = tt .
+
+  eq ff /\ ff = ff .
+  eq tt \/ tt = tt .
 
   eq ff /\ EqL = ff .
   eq tt \/ EqL = tt .
 
   eq EqL /\ EqL = EqL .
   eq EqL \/ EqL = EqL .
+
+  eq X ?= X = tt .
+  eq X != X = ff .
+
+  eq X ?= X' /\ X != X' = ff .
+  eq X ?= X' \/ X != X' = tt .
 
   --- Implication
   op _=>_  : Form{X} Form{X} -> Form{X} .

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -633,3 +633,67 @@ fmod EQFORM-OPERATIONS is
   eq toUnifProb(T ?= T')           = T =? T' .
 endfm
 ```
+
+```maude
+fmod EQFORM-SET-OPERATIONS is
+  pr EQFORM-OPERATIONS .
+  pr EQFORM-SET .
+  pr EQFORM-CNF .
+  pr EQFORM-DNF .
+
+  var C : EqConj . var D : EqDisj .
+  var FS : FormSet . var F F' : Form . var UP : UnificationProblem .
+  var PEA : PosEqLit . var PELS : PosEqLitSet . var T T' : Term . var M : Module .
+
+  op wellFormed : Module FormSet -> Bool .
+  ----------------------------------------
+  eq wellFormed(M , F | F' | FS) = wellFormed(M,F) and-then wellFormed(M,F' | FS) .
+  eq wellFormed(M , mtFormSet)   = true .
+
+  op disj-join : FormSet -> [Form] .
+  op disj-join : FormSet -> [Form] .
+  ----------------------------------
+  eq disj-join(F | FS)    = F \/ disj-join(FS) .
+  eq disj-join(mtFormSet) = ff .
+
+  op conj-join : FormSet -> [Form] .
+  op conj-join : FormSet -> [Form] .
+  ----------------------------------
+  eq conj-join(F | FS)    = F /\ conj-join(FS) .
+  eq conj-join(mtFormSet) = tt .
+
+  op toDisjSet  : Form -> [EqDisjSet] .
+  op toDisjSet' : Form -> [EqDisjSet] .
+  -------------------------------------
+  eq toDisjSet (F)      = toDisjSet'(cnf(F)) .
+  eq toDisjSet'(tt)     = mtFormSet .
+  eq toDisjSet'(ff)     = mtFormSet .
+  eq toDisjSet'(D /\ F) = D | toDisjSet'(F) .
+
+  op toConjSet  : Form -> [EqConjSet] .
+  op toConjSet' : Form -> [EqConjSet] .
+  -------------------------------------
+  eq toConjSet (F)      = toConjSet'(dnf(F)) .
+  eq toConjSet'(tt)     = mtFormSet .
+  eq toConjSet'(ff)     = mtFormSet .
+  eq toConjSet'(C \/ F) = C | toConjSet'(F) .
+
+  op toEqSet : PosEqLitSet -> EquationSet .
+  -----------------------------------------
+  eq toEqSet((T ?= T') | PELS) = (eq T = T' [none] .) toEqSet(PELS) .
+  eq toEqSet(mtFormSet)        = none .
+
+  op toPosEqLits : PosEqForm          -> PosEqLitSet .
+  op toPosEqLits : UnificationProblem -> PosEqLitSet .
+  ----------------------------------------------------
+  eq toPosEqLits(tt)      = mtFormSet .
+  eq toPosEqLits(ff)      = mtFormSet .
+  eq toPosEqLits(T ?= T') = T ?= T' .
+  eq toPosEqLits(~ F)     = toPosEqLits(F) .
+ ceq toPosEqLits(F /\ F') = toPosEqLits(F) | toPosEqLits(F') if F =/= tt /\ F' =/= tt .
+ ceq toPosEqLits(F \/ F') = toPosEqLits(F) | toPosEqLits(F') if F =/= ff /\ F' =/= ff .
+
+  eq toPosEqLits(T =? T' /\ UP) = (T ?= T') | toPosEqLits(UP) .
+  eq toPosEqLits(T =? T')       = T ?= T' .
+endfm
+```

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -207,30 +207,30 @@ fmod EQFORM-IMPL{X :: TRIV} is
   var EqL : EqLit{X} .
   vars F F' : Form{X} .
 
-  eq ~ tt = ff .
-  eq ~ ff = tt .
+  eq ~ tt = ff [variant] .
+  eq ~ ff = tt [variant] .
 
-  eq ff /\ ff = ff .
-  eq tt \/ tt = tt .
+  eq ff /\ ff = ff [variant] .
+  eq tt \/ tt = tt [variant] .
 
-  eq ff /\ EqL = ff .
-  eq tt \/ EqL = tt .
+  eq ff /\ EqL = ff [variant] .
+  eq tt \/ EqL = tt [variant] .
 
-  eq EqL /\ EqL = EqL .
-  eq EqL \/ EqL = EqL .
+  eq EqL /\ EqL = EqL [variant] .
+  eq EqL \/ EqL = EqL [variant] .
 
-  eq X ?= X = tt .
-  eq X != X = ff .
+  eq X ?= X = tt [variant] .
+  eq X != X = ff [variant] .
 
-  eq X ?= X' /\ X != X' = ff .
-  eq X ?= X' \/ X != X' = tt .
+  eq X ?= X' /\ X != X' = ff [variant] .
+  eq X ?= X' \/ X != X' = tt [variant] .
 
   --- Implication
   op _=>_  : Form{X} Form{X} -> Form{X} .
   op _<=>_ : Form{X} Form{X} -> Form{X} .
   ---------------------------------------
-  eq F  => F' = (~ F) \/ F' .
-  eq F <=> F' = (F => F') /\ (F' => F) .
+  eq F  => F' = (~ F) \/ F'            [variant] .
+  eq F <=> F' = (F => F') /\ (F' => F) [variant] .
 endfm
 
 view Term from TRIV to META-TERM is sort Elt to Term . endv

--- a/tests/systems/imp.expected
+++ b/tests/systems/imp.expected
@@ -24,25 +24,25 @@ result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 * y |-> 1 +Nat
 ==========================================
 rewrite in IMP-TEST : < swap-sort(x ; y ; z) ~> done | x |-> 3 * y |-> 4 * z
     |-> 5 > .
-rewrites: 72
+rewrites: 79
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 * y |-> 1 +Nat 1 +Nat 1 +Nat
     1 * z |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 >
 ==========================================
 rewrite in IMP-TEST : < swap-sort(x ; z ; y) ~> done | x |-> 3 * y |-> 4 * z
     |-> 5 > .
-rewrites: 115
+rewrites: 122
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 * y |-> 1 +Nat 1 +Nat 1 +Nat
     1 +Nat 1 * z |-> 1 +Nat 1 +Nat 1 +Nat 1 >
 ==========================================
 rewrite in IMP-TEST : < swap-sort(y ; z ; x) ~> done | x |-> 3 * y |-> 4 * z
     |-> 5 > .
-rewrites: 158
+rewrites: 166
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 * y |-> 1 +Nat
     1 +Nat 1 * z |-> 1 +Nat 1 +Nat 1 +Nat 1 >
 ==========================================
 rewrite in IMP-TEST : < swap-sort(y ; z ; q ; x ; r) ~> done | x |-> 3 * y |->
     4 * z |-> 5 * q |-> 3 * r |-> 7 > .
-rewrites: 521
+rewrites: 558
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 * y |-> 1 +Nat
     1 +Nat 1 * z |-> 1 +Nat 1 +Nat 1 * q |-> 1 +Nat 1 +Nat 1 +Nat 1 * r |-> 1
     +Nat 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 >

--- a/tests/systems/thermostat.expected
+++ b/tests/systems/thermostat.expected
@@ -42,337 +42,337 @@ C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,off}
 
 Solution 2 (state 1)
-states: 2  rewrites: 65
+states: 2  rewrites: 84
 C:Conf --> < 1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 3 (state 2)
-states: 3  rewrites: 106
+states: 3  rewrites: 144
 C:Conf --> {1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 4 (state 3)
-states: 4  rewrites: 107
+states: 4  rewrites: 145
 C:Conf --> < 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 5 (state 4)
-states: 5  rewrites: 109
+states: 5  rewrites: 147
 C:Conf --> {1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,delay(on)}
 
 Solution 6 (state 5)
-states: 6  rewrites: 110
+states: 6  rewrites: 148
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1,delay(on) >
 
 Solution 7 (state 6)
-states: 7  rewrites: 112
+states: 7  rewrites: 150
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,delay(on)}
 
 Solution 8 (state 7)
-states: 8  rewrites: 113
+states: 8  rewrites: 151
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,delay(on) >
 
 Solution 9 (state 8)
-states: 9  rewrites: 115
+states: 9  rewrites: 153
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on)}
 
 Solution 10 (state 9)
-states: 10  rewrites: 116
+states: 10  rewrites: 154
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on) >
 
 Solution 11 (state 10)
-states: 11  rewrites: 118
+states: 11  rewrites: 156
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on)}
 
 Solution 12 (state 11)
-states: 12  rewrites: 119
+states: 12  rewrites: 157
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 13 (state 12)
-states: 13  rewrites: 123
+states: 13  rewrites: 161
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,on}
 
 Solution 14 (state 13)
-states: 14  rewrites: 194
+states: 14  rewrites: 270
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,on >
 
 Solution 15 (state 14)
-states: 15  rewrites: 198
+states: 15  rewrites: 274
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1,on}
 
 Solution 16 (state 15)
-states: 16  rewrites: 269
+states: 16  rewrites: 387
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1,on >
 
 Solution 17 (state 16)
-states: 17  rewrites: 273
+states: 17  rewrites: 391
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1,on}
 
 Solution 18 (state 17)
-states: 18  rewrites: 344
+states: 18  rewrites: 508
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,on >
 
 Solution 19 (state 18)
-states: 19  rewrites: 348
+states: 19  rewrites: 512
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 20 (state 19)
-states: 20  rewrites: 419
+states: 20  rewrites: 633
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 21 (state 20)
-states: 21  rewrites: 423
+states: 21  rewrites: 637
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 22 (state 21)
-states: 22  rewrites: 462
+states: 22  rewrites: 701
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 23 (state 22)
-states: 23  rewrites: 499
+states: 23  rewrites: 763
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 24 (state 23)
-states: 24  rewrites: 500
+states: 24  rewrites: 764
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 25 (state 24)
-states: 25  rewrites: 502
+states: 25  rewrites: 766
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 26 (state 25)
-states: 26  rewrites: 503
+states: 26  rewrites: 767
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 27 (state 26)
-states: 27  rewrites: 505
+states: 27  rewrites: 769
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 28 (state 27)
-states: 28  rewrites: 506
+states: 28  rewrites: 770
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,off >
 
 Solution 29 (state 28)
-states: 29  rewrites: 508
+states: 29  rewrites: 772
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1,off}
 
 Solution 30 (state 29)
-states: 30  rewrites: 555
+states: 30  rewrites: 837
 C:Conf --> < 1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 31 (state 30)
-states: 31  rewrites: 596
+states: 31  rewrites: 896
 C:Conf --> {1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 32 (state 31)
-states: 32  rewrites: 597
+states: 32  rewrites: 897
 C:Conf --> < 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1,delay(on) >
 
 Solution 33 (state 32)
-states: 33  rewrites: 599
+states: 33  rewrites: 899
 C:Conf --> {1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1,delay(on)}
 
 Solution 34 (state 33)
-states: 34  rewrites: 600
+states: 34  rewrites: 900
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1,delay(on) >
 
 Solution 35 (state 34)
-states: 35  rewrites: 602
+states: 35  rewrites: 902
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,delay(on)}
 
 Solution 36 (state 35)
-states: 36  rewrites: 603
+states: 36  rewrites: 903
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on) >
 
 Solution 37 (state 36)
-states: 37  rewrites: 605
+states: 37  rewrites: 905
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on)}
 
 Solution 38 (state 37)
-states: 38  rewrites: 606
+states: 38  rewrites: 906
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on) >
 
 Solution 39 (state 38)
-states: 39  rewrites: 608
+states: 39  rewrites: 908
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 40 (state 39)
-states: 40  rewrites: 609
+states: 40  rewrites: 909
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 41 (state 40)
-states: 41  rewrites: 613
+states: 41  rewrites: 913
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 42 (state 41)
-states: 42  rewrites: 684
+states: 42  rewrites: 1020
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on
     >
 
 Solution 43 (state 42)
-states: 43  rewrites: 688
+states: 43  rewrites: 1024
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,on}
 
 Solution 44 (state 43)
-states: 44  rewrites: 759
+states: 44  rewrites: 1135
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1,on >
 
 Solution 45 (state 44)
-states: 45  rewrites: 763
+states: 45  rewrites: 1139
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,on}
 
 Solution 46 (state 45)
-states: 46  rewrites: 834
+states: 46  rewrites: 1254
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1,on >
 
 Solution 47 (state 46)
-states: 47  rewrites: 838
+states: 47  rewrites: 1258
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 48 (state 47)
-states: 48  rewrites: 909
+states: 48  rewrites: 1377
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 49 (state 48)
-states: 49  rewrites: 913
+states: 49  rewrites: 1381
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 50 (state 49)
-states: 50  rewrites: 952
+states: 50  rewrites: 1445
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 51 (state 50)
-states: 51  rewrites: 989
+states: 51  rewrites: 1507
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 52 (state 51)
-states: 52  rewrites: 990
+states: 52  rewrites: 1508
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 53 (state 52)
-states: 53  rewrites: 992
+states: 53  rewrites: 1510
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 54 (state 53)
-states: 54  rewrites: 993
+states: 54  rewrites: 1511
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 55 (state 54)
-states: 55  rewrites: 995
+states: 55  rewrites: 1513
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 56 (state 55)
-states: 56  rewrites: 996
+states: 56  rewrites: 1514
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,off >
 
 Solution 57 (state 56)
-states: 57  rewrites: 998
+states: 57  rewrites: 1516
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,off}
 
 Solution 58 (state 57)
-states: 58  rewrites: 1045
+states: 58  rewrites: 1580
 C:Conf --> < 1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 59 (state 58)
-states: 59  rewrites: 1086
+states: 59  rewrites: 1638
 C:Conf --> {1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,delay(on)}
 
 Solution 60 (state 59)
-states: 60  rewrites: 1087
+states: 60  rewrites: 1639
 C:Conf --> < 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1,delay(on) >
 
 Solution 61 (state 60)
-states: 61  rewrites: 1089
+states: 61  rewrites: 1641
 C:Conf --> {1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,delay(on)}
 
 Solution 62 (state 61)
-states: 62  rewrites: 1090
+states: 62  rewrites: 1642
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,delay(on) >
 
 Solution 63 (state 62)
-states: 63  rewrites: 1092
+states: 63  rewrites: 1644
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on)}
 
 Solution 64 (state 63)
-states: 64  rewrites: 1093
+states: 64  rewrites: 1645
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on) >
 
 Solution 65 (state 64)
-states: 65  rewrites: 1095
+states: 65  rewrites: 1647
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 66 (state 65)
-states: 66  rewrites: 1096
+states: 66  rewrites: 1648
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)
     >
 
 Solution 67 (state 66)
-states: 67  rewrites: 1098
+states: 67  rewrites: 1650
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 68 (state 67)
-states: 68  rewrites: 1099
+states: 68  rewrites: 1651
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 69 (state 68)
-states: 69  rewrites: 1103
+states: 69  rewrites: 1655
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 No more solutions.
-states: 69  rewrites: 1174
+states: 69  rewrites: 1760
 Bye.

--- a/tests/tools/fvp/numbers.expected
+++ b/tests/tools/fvp/numbers.expected
@@ -364,11 +364,11 @@ NzN:NzNat --> 1
 No more variants.
 rewrites: 2
 ==========================================
-get variants in FVP-NAT-PRED : NzN < N + NzN .
+get variants in FVP-NAT-PRED : NzN < NzN + N .
 
 Variant #1
 rewrites: 0
-Bool: #1:NzNat < #2:Nat + #1:NzNat
+Bool: #1:NzNat < #1:NzNat + #2:Nat
 NzN --> #1:NzNat
 N --> #2:Nat
 
@@ -398,19 +398,19 @@ NzN --> #2:NzNat
 Variant #2
 rewrites: 2
 Bool: true
-N --> %1:Nat
-NzN --> %1:Nat + %2:NzNat
+N --> %2:Nat
+NzN --> %1:NzNat + %2:Nat
 
 Variant #3
 rewrites: 2
 Bool: false
-N --> %2:Nat + %1:NzNat
+N --> %1:NzNat + %2:Nat
 NzN --> %1:NzNat
 
 No more variants.
 rewrites: 2
 ==========================================
-get variants in FVP-NAT-PRED : NzN <= N + NzN .
+get variants in FVP-NAT-PRED : NzN <= NzN + N .
 
 Variant #1
 rewrites: 1
@@ -433,19 +433,19 @@ Variant #2
 rewrites: 3
 Bool: true
 N --> %1:NzNat
-NzN --> %2:Nat + %1:NzNat
+NzN --> %1:NzNat + %2:Nat
 
 Variant #3
 rewrites: 3
 Bool: true
 N --> %1:Nat
-NzN --> %1:Nat + %2:NzNat
+NzN --> %2:NzNat + %1:Nat
 
 Variant #4
 rewrites: 3
 Bool: false
 N --> %1:NzNat + %2:NzNat
-NzN --> %1:NzNat
+NzN --> %2:NzNat
 
 No more variants.
 rewrites: 3

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -216,4 +216,14 @@ reduce in EQFORM-TEST : toPosEqLits(f3) .
 rewrites: 19
 result PosEqLitNeSet: ('B:Bar ?= 'foo.Foo) | ('H:Baz ?= 'f['I:Wop]) | ('U:Stu
     ?= 'W:Roc)
+==========================================
+reduce in EQFORM-TEST : (f1 | f2) << (
+  'H:Baz <- 'bar.Bar) | (
+  'H:Baz <- 'baz.Baz) == (f1 << (
+  'H:Baz <- 'baz.Baz)) | (f1 << (
+  'H:Baz <- 'bar.Bar)) | (f2 << (
+  'H:Baz <- 'bar.Bar)) | (f2 << (
+  'H:Baz <- 'baz.Baz)) .
+rewrites: 461
+result Bool: true
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -17,24 +17,25 @@ reduce in EQFORM-TEST : f1 << (
   'F:Foo <- 'F2:Foo ; 
   'I:Wop <- 'I2:Wop ; 
   'U:Stu <- 'U2:Stu) .
-rewrites: 95
-result NonTrivForm: ~ ('F2:Foo ?= 'G:Bar /\ 'F2:Foo != 'G:Bar) \/ ~ ('K:Foo ?=
-    'L:Bar /\ 'H:Baz ?= 'I2:Wop \/ 'H:Baz != 'I2:Wop)
+rewrites: 94
+result NonTrivForm: ~ ('B:Bar ?= 'foo.Foo /\ 'F2:Foo != 'f['bar.Bar]) \/ ~ (
+    'K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I2:Wop] \/ 'f['H:Baz] != 'f['f['I2:Wop]])
 ==========================================
 reduce in EQFORM-TEST : f2 << (
   'F:Foo <- 'F2:Foo ; 
   'I:Wop <- 'I2:Wop ; 
   'U:Stu <- 'U2:Stu) .
-rewrites: 121
-result NonTrivForm: ~ 'U2:Stu ?= 'W:Roc /\ ~ ('F2:Foo ?= 'G:Bar /\ 'F2:Foo !=
-    'G:Bar) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'I2:Wop \/ 'H:Baz != 'I2:Wop)
+rewrites: 123
+result NonTrivForm: ~ 'U2:Stu ?= 'W:Roc /\ ~ ('B:Bar ?= 'foo.Foo /\ 'F2:Foo !=
+    'f['bar.Bar]) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I2:Wop] \/ 'f['H:Baz]
+    != 'f['f['I2:Wop]])
 ==========================================
 reduce in EQFORM-TEST : f1 :: Form .
-rewrites: 7
+rewrites: 12
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : f2 :: Form .
-rewrites: 11
+rewrites: 19
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : ff .
@@ -54,45 +55,45 @@ rewrites: 0
 result Form: F:Form
 ==========================================
 reduce in EQFORM-TEST : nnf(f1) .
-rewrites: 15
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
-    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 20
+result EqForm: 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar
+    \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : nnf(f2) .
-rewrites: 21
-result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
-    'K:Foo != 'L:Bar \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 29
+result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo
+    \/ 'K:Foo != 'L:Bar \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : nef(f1) .
-rewrites: 17
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
-    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 22
+result EqForm: 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar
+    \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : nef(f2) .
-rewrites: 23
-result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
-    'K:Foo != 'L:Bar \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 31
+result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo
+    \/ 'K:Foo != 'L:Bar \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : cnf(f1) .
-rewrites: 57
-result EqForm: ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/ 'F:Foo != 'G:Bar \/
-    'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'H:Baz !=
-    'I:Wop \/ 'K:Foo != 'L:Bar
+rewrites: 62
+result EqForm: ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz] ?= 'f['f['I:Wop]] \/
+    'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar
+    != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo != 'L:Bar
 ==========================================
 reduce in EQFORM-TEST : cnf(f2) .
-rewrites: 67
-result EqForm: 'U:Stu != 'W:Roc /\ ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/
-    'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo !=
-    'G:Bar \/ 'H:Baz != 'I:Wop \/ 'K:Foo != 'L:Bar
+rewrites: 75
+result EqForm: 'U:Stu != 'W:Roc /\ ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz] ?= 'f[
+    'f['I:Wop]] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'f[
+    'bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo != 'L:Bar
 ==========================================
 reduce in EQFORM-TEST : dnf(f1) .
-rewrites: 31
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
-    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 36
+result EqForm: 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar
+    \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : dnf(f2) .
-rewrites: 69
-result EqForm: ('F:Foo ?= 'G:Bar /\ 'U:Stu != 'W:Roc) \/ ('F:Foo != 'G:Bar /\
-    'U:Stu != 'W:Roc) \/ ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) \/ 'H:Baz ?=
-    'I:Wop /\ 'H:Baz != 'I:Wop /\ 'U:Stu != 'W:Roc
+rewrites: 77
+result EqForm: ('F:Foo ?= 'f['bar.Bar] /\ 'U:Stu != 'W:Roc) \/ ('B:Bar !=
+    'foo.Foo /\ 'U:Stu != 'W:Roc) \/ ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) \/
+    'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop] /\ 'U:Stu != 'W:Roc
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -179,4 +179,41 @@ reduce in EQFORM-TEST : toUnifProb(a /\ c /\ e) .
 rewrites: 7
 result UnificationProblem: 'B:Bar =? 'foo.Foo /\ 'H:Baz =? 'f['I:Wop] /\ 'U:Stu
     =? 'W:Roc
+==========================================
+reduce in EQFORM-TEST : toConjSet(t1 ?= t2) .
+rewrites: 16
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : toDisjSet(t1 ?= t2) .
+rewrites: 16
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : toConjSet(f1) .
+rewrites: 42
+result EqConjNeSet: ('F:Foo ?= 'f['bar.Bar]) | ('B:Bar != 'foo.Foo) | ('K:Foo
+    != 'L:Bar) | ('f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop])
+==========================================
+reduce in EQFORM-TEST : toDisjSet(f1) .
+rewrites: 66
+result EqDisjNeSet: ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz] ?= 'f['f['I:Wop]] \/
+    'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) | ('F:Foo ?= 'f['bar.Bar] \/ 'B:Bar
+    != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo != 'L:Bar)
+==========================================
+reduce in EQFORM-TEST : toConjSet(f2) .
+rewrites: 83
+result EqConjNeSet: ('F:Foo ?= 'f['bar.Bar] /\ 'U:Stu != 'W:Roc) | ('B:Bar !=
+    'foo.Foo /\ 'U:Stu != 'W:Roc) | ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) | (
+    'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop] /\ 'U:Stu != 'W:Roc)
+==========================================
+reduce in EQFORM-TEST : toDisjSet(f2) .
+rewrites: 80
+result EqDisjNeSet: ('U:Stu != 'W:Roc) | ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz]
+    ?= 'f['f['I:Wop]] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) | ('F:Foo ?=
+    'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo !=
+    'L:Bar)
+==========================================
+reduce in EQFORM-TEST : toPosEqLits(f3) .
+rewrites: 19
+result PosEqLitNeSet: ('B:Bar ?= 'foo.Foo) | ('H:Baz ?= 'f['I:Wop]) | ('U:Stu
+    ?= 'W:Roc)
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -96,4 +96,87 @@ rewrites: 77
 result EqForm: ('F:Foo ?= 'f['bar.Bar] /\ 'U:Stu != 'W:Roc) \/ ('B:Bar !=
     'foo.Foo /\ 'U:Stu != 'W:Roc) \/ ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) \/
     'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop] /\ 'U:Stu != 'W:Roc
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+rewrites: 22
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), c) .
+rewrites: 19
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), f1) .
+rewrites: 112
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), f2) .
+rewrites: 139
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), f1 /\ '0.Term
+    ?= 'T:BadSort) .
+rewrites: 28
+result Bool: false
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('NAT), '0.Nat ?= 's_['s_['0.Nat]]) .
+rewrites: 13
+result PosEqLit: '0.Zero ?= 's_^2['0.Zero]
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+rewrites: 16
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+rewrites: 16
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), f(t2) ?= f(f(
+    t1))) .
+rewrites: 19
+result PosEqLit: 'f['bar.Bar] ?= 'f['f['f['f['B:Baz]]]]
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), f(t2) ?= f(f(
+    t1))) .
+rewrites: 20
+result PosEqLit: 'baz.Baz ?= 'f['f['f['f['B:Baz]]]]
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), f1) .
+rewrites: 91
+result NonTrivForm: ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo != 'f['bar.Bar]) \/ ~ (
+    'K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz] != 'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), f1) .
+rewrites: 92
+result NonTrivForm: ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo != 'baz.Baz) \/ ~ ('K:Foo
+    ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz] != 'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), f2) .
+rewrites: 114
+result NonTrivForm: ~ 'U:Stu ?= 'W:Roc /\ ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo !=
+    'f['bar.Bar]) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz]
+    != 'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), f2) .
+rewrites: 115
+result NonTrivForm: ~ 'U:Stu ?= 'W:Roc /\ ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo !=
+    'baz.Baz) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz] !=
+    'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : vars('0.Nat ?= 's_['s_['X:Nat]]) .
+rewrites: 11
+result Variable: 'X:Nat
+==========================================
+reduce in EQFORM-TEST : vars(f1) .
+rewrites: 86
+result NeQidSet: 'B:Bar ; 'F:Foo ; 'H:Baz ; 'I:Wop ; 'K:Foo ; 'L:Bar
+==========================================
+reduce in EQFORM-TEST : vars(f2) .
+rewrites: 107
+result NeQidSet: 'B:Bar ; 'F:Foo ; 'H:Baz ; 'I:Wop ; 'K:Foo ; 'L:Bar ; 'U:Stu ;
+    'W:Roc
+==========================================
+reduce in EQFORM-TEST : toUnifProb(a /\ c /\ e) .
+rewrites: 7
+result UnificationProblem: 'B:Bar =? 'foo.Foo /\ 'H:Baz =? 'f['I:Wop] /\ 'U:Stu
+    =? 'W:Roc
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -1,4 +1,219 @@
 ==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(B:Baz)) .
+
+Variant #1
+rewrites: 0
+Baz: f(f(#1:Baz))
+B:Baz --> #1:Baz
+
+Variant #2
+rewrites: 8
+Baz: baz
+B:Baz --> baz
+
+Variant #3
+rewrites: 8
+Baz: baz
+B:Baz --> bar
+
+Variant #4
+rewrites: 8
+Baz: baz
+B:Baz --> foo
+
+Variant #5
+rewrites: 8
+Wop: wop
+B:Baz --> wop
+
+No more variants.
+rewrites: 8
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(B:Bar)) .
+
+Variant #1
+rewrites: 0
+Baz: f(f(#1:Bar))
+B:Bar --> #1:Bar
+
+Variant #2
+rewrites: 4
+Baz: baz
+B:Bar --> bar
+
+Variant #3
+rewrites: 4
+Wop: wop
+B:Bar --> wop
+
+No more variants.
+rewrites: 4
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(W:Wop)) .
+
+Variant #1
+rewrites: 0
+Baz: f(f(#1:Wop))
+W:Wop --> #1:Wop
+
+Variant #2
+rewrites: 2
+Wop: wop
+W:Wop --> wop
+
+No more variants.
+rewrites: 2
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(B:Baz)) ?= f(f(B:Bar)) .
+
+Variant #1
+rewrites: 0
+PosEqLit{Baz}: f(f(#1:Baz)) ?= f(f(#2:Bar))
+B:Baz --> #1:Baz
+B:Bar --> #2:Bar
+
+Variant #2
+rewrites: 13
+TrueLit{Baz}: tt
+B:Baz --> %1:Bar
+B:Bar --> %1:Bar
+
+Variant #3
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Bar))
+B:Baz --> baz
+B:Bar --> %1:Bar
+
+Variant #4
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Bar))
+B:Baz --> bar
+B:Bar --> %1:Bar
+
+Variant #5
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Bar))
+B:Baz --> foo
+B:Bar --> %1:Bar
+
+Variant #6
+rewrites: 13
+PosEqLit{Baz}: wop ?= f(f(%1:Bar))
+B:Baz --> wop
+B:Bar --> %1:Bar
+
+Variant #7
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Baz))
+B:Baz --> %1:Baz
+B:Bar --> bar
+
+Variant #8
+rewrites: 13
+PosEqLit{Baz}: wop ?= f(f(%1:Baz))
+B:Baz --> %1:Baz
+B:Bar --> wop
+
+Variant #9
+rewrites: 53
+TrueLit{Baz}: tt
+B:Baz --> baz
+B:Bar --> bar
+
+Variant #10
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> baz
+B:Bar --> wop
+
+Variant #11
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> bar
+B:Bar --> wop
+
+Variant #12
+rewrites: 53
+TrueLit{Baz}: tt
+B:Baz --> foo
+B:Bar --> bar
+
+Variant #13
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> foo
+B:Bar --> wop
+
+Variant #14
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> wop
+B:Bar --> bar
+
+No more variants.
+rewrites: 53
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : W:Wop ?= f(f(B:Baz)) .
+
+Variant #1
+rewrites: 0
+PosEqLit{Baz}: #1:Wop ?= f(f(#2:Baz))
+W:Wop --> #1:Wop
+B:Baz --> #2:Baz
+
+Variant #2
+rewrites: 8
+PosEqLit{Baz}: baz ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> baz
+
+Variant #3
+rewrites: 8
+PosEqLit{Baz}: baz ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> bar
+
+Variant #4
+rewrites: 8
+PosEqLit{Baz}: baz ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> foo
+
+Variant #5
+rewrites: 8
+PosEqLit{Baz}: wop ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> wop
+
+Variant #6
+rewrites: 9
+TrueLit{Baz}: tt
+W:Wop --> wop
+B:Baz --> wop
+
+No more variants.
+rewrites: 9
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : baz ?= f(B:Bar) .
+
+Variant #1
+rewrites: 0
+PosEqLit{Baz}: baz ?= f(#1:Bar)
+B:Bar --> #1:Bar
+
+Variant #2
+rewrites: 3
+TrueLit{Baz}: tt
+B:Bar --> bar
+
+Variant #3
+rewrites: 3
+PosEqLit{Baz}: wop ?= baz
+B:Bar --> wop
+
+No more variants.
+rewrites: 3
+==========================================
 reduce in EQFORM-TEST : ('_*_['Y:Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\
     'true.Bool != '_<_['Y:Nat,'Z:Nat]) << (
   'Y:Nat <- '3.Nat) == ('_*_['3.Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -38,6 +38,22 @@ reduce in EQFORM-TEST : f2 :: Form .
 rewrites: 19
 result Bool: true
 ==========================================
+reduce in EQFORM-TEST : tt .
+rewrites: 0
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : tt \/ tt .
+rewrites: 1
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : ff /\ ff .
+rewrites: 1
+result FalseLit: ff
+==========================================
+reduce in EQFORM-TEST : ff .
+rewrites: 0
+result FalseLit: ff
+==========================================
 reduce in EQFORM-TEST : ff .
 rewrites: 0
 result FalseLit: ff
@@ -53,6 +69,22 @@ result Form: F:Form
 reduce in EQFORM-TEST : F:Form .
 rewrites: 0
 result Form: F:Form
+==========================================
+reduce in EQFORM-TEST : 'B:Bar ?= 'foo.Foo /\ 'B:Bar != 'foo.Foo .
+rewrites: 1
+result FalseLit: ff
+==========================================
+reduce in EQFORM-TEST : 'B:Bar ?= 'foo.Foo \/ 'B:Bar != 'foo.Foo .
+rewrites: 1
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : t1 ?= t1 .
+rewrites: 4
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : t1 != t1 .
+rewrites: 4
+result FalseLit: ff
 ==========================================
 reduce in EQFORM-TEST : nnf(f1) .
 rewrites: 20

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -27,6 +27,7 @@ fmod EQFORM-TEST is
   inc EQFORM-LIST .
   inc EQFORM-SET .
   inc EQFORM-OPERATIONS .
+  inc EQFORM-SET-OPERATIONS .
 
   var T : Term .
 
@@ -52,6 +53,9 @@ fmod EQFORM-TEST is
 
   op f2 : -> Form .
   eq f2 = (f1 /\ ~ e) /\ (d \/ tt) .
+
+  op f3 : -> Form .
+  eq f3 = (a /\ c) \/ e .
 endfm
 
 --- substitutions
@@ -112,3 +116,14 @@ reduce vars(f1) .
 reduce vars(f2) .
 
 reduce toUnifProb(a /\ c /\ e) .
+
+reduce toConjSet(t1 ?= t2) .
+reduce toDisjSet(t1 ?= t2) .
+
+reduce toConjSet(f1) .
+reduce toDisjSet(f1) .
+
+reduce toConjSet(f2) .
+reduce toDisjSet(f2) .
+
+reduce toPosEqLits(f3) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -15,11 +15,25 @@ fmod EQFORM-TEST-MODULE is
 
     op f : Baz -> Baz .
     -------------------
-    eq f(baz) = baz .
-    eq f(bar) = baz .
-    eq f(foo) = bar .
-    eq f(wop) = wop .
+    eq f(baz) = baz [variant] .
+    eq f(bar) = baz [variant] .
+    eq f(foo) = bar [variant] .
+    eq f(wop) = wop [variant] .
 endfm
+
+view Baz from TRIV to EQFORM-TEST-MODULE is sort Elt to Baz . endv
+
+fmod EQFORM-TEST-INSTANTIATION is
+    protecting EQFORM-IMPL{Baz} .
+endfm
+
+get variants f(f(B:Baz)) .
+get variants f(f(B:Bar)) .
+get variants f(f(W:Wop)) .
+
+get variants f(f(B:Baz)) ?= f(f(B:Bar)) .
+get variants f(f(B:Baz)) ?= W:Wop .
+get variants baz ?= f(B:Bar) .
 
 fmod EQFORM-TEST is
   inc EQFORM-CNF .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -127,3 +127,10 @@ reduce toConjSet(f2) .
 reduce toDisjSet(f2) .
 
 reduce toPosEqLits(f3) .
+
+reduce (f1 | f2) << (('H:Baz <- 'baz.Baz) | ('H:Baz <- 'bar.Bar))
+    == ( ( f1 << ('H:Baz <- 'baz.Baz) )
+       | ( f1 << ('H:Baz <- 'bar.Bar) )
+       | ( f2 << ('H:Baz <- 'baz.Baz) )
+       | ( f2 << ('H:Baz <- 'bar.Bar) )
+       ) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -26,6 +26,7 @@ fmod EQFORM-TEST is
   inc EQFORM-DNF .
   inc EQFORM-LIST .
   inc EQFORM-SET .
+  inc EQFORM-OPERATIONS .
 
   var T : Term .
 
@@ -87,3 +88,27 @@ reduce cnf(f2) .
 
 reduce dnf(f1) .
 reduce dnf(f2) .
+
+--- testing operations
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), c) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), f1) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), f2) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), f1 /\ 'T:BadSort ?= '0.Term) .
+
+reduce normalize(upModule('NAT), 's_['s_['0.Nat]] ?= '0.Nat) .
+
+reduce normalize(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+reduce normalize(upModule('EQFORM-TEST-MODULE), f(f(t1)) ?= f(t2)) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), f(f(t1)) ?= f(t2)) .
+reduce normalize(upModule('EQFORM-TEST-MODULE), f1) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), f1) .
+reduce normalize(upModule('EQFORM-TEST-MODULE), f2) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), f2) .
+
+reduce vars('s_ ['s_['X:Nat]] ?= '0.Nat) .
+reduce vars(f1) .
+reduce vars(f2) .
+
+reduce toUnifProb(a /\ c /\ e) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -73,12 +73,25 @@ reduce f1 :: Form .
 reduce f2 :: Form .
 
 --- testing identities
+reduce tt /\ tt .
+reduce tt \/ tt .
+
+reduce ff /\ ff .
+reduce ff \/ ff .
+
 reduce tt /\ ff .
 reduce tt \/ ff .
 
 --- testing idempotency
 reduce tt /\ F:Form .
 reduce ff \/ F:Form .
+
+--- simplifications
+reduce 'B:Bar ?= 'foo.Foo /\ 'B:Bar != 'foo.Foo .
+reduce 'B:Bar ?= 'foo.Foo \/ 'B:Bar != 'foo.Foo .
+
+reduce t1 ?= t1 .
+reduce t1 != t1 .
 
 --- testing transformations
 reduce nnf(f1) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -1,18 +1,49 @@
 load ../../../contrib/tools/meta/eqform.maude
 
+fmod EQFORM-TEST-MODULE is
+    sorts Foo Bar Baz Wop Stu Roc .
+    -------------------------------
+    subsorts Wop < Foo Bar < Baz .
+    subsorts Roc < Stu .
+
+    op wop : -> Wop .
+    op foo : -> Foo .
+    op bar : -> Bar .
+    op baz : -> Baz .
+    op roc : -> Roc .
+    op stu : -> Stu .
+
+    op f : Baz -> Baz .
+    -------------------
+    eq f(baz) = baz .
+    eq f(bar) = baz .
+    eq f(foo) = bar .
+    eq f(wop) = wop .
+endfm
+
 fmod EQFORM-TEST is
   inc EQFORM-CNF .
   inc EQFORM-DNF .
   inc EQFORM-LIST .
   inc EQFORM-SET .
 
-  ops t1 t2 : -> Term .
-  ops a b c d e : -> EqLit .
+  var T : Term .
 
-  eq a = 'F:Foo ?= 'G:Bar .
-  eq b = 'F:Foo != 'G:Bar .
-  eq c = 'H:Baz ?= 'I:Wop .
-  eq d = 'H:Baz != 'I:Wop .
+  op f : Term -> Term .
+  ---------------------
+  eq f(T) = 'f[T] .
+
+  ops t1 t2 : -> Term .
+  ---------------------
+  eq t1 = f(f('B:Baz)) .
+  eq t2 = 'bar.Bar .
+
+  ops a b c d e : -> EqLit .
+  --------------------------
+  eq a = 'foo.Foo ?= 'B:Bar .
+  eq b = 'F:Foo != f('bar.Bar) .
+  eq c = 'H:Baz ?= f('I:Wop) .
+  eq d = f('H:Baz) != f(f('I:Wop)) .
   eq e = 'U:Stu ?= 'W:Roc .
 
   op f1 : -> Form .

--- a/tests/tools/meta/mtemplate.expected
+++ b/tests/tools/meta/mtemplate.expected
@@ -185,8 +185,12 @@ result NeModuleDeclSet: (sorts 'BState ; 'Bool ; 'Mode ; 'Nat ; 'NcMode ;
 subsort 'NcMode < 'Mode .
 subsort 'NzNat < 'Nat .
 eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
+eq '_<=_['_+_['1.NzNat,'NzN:NzNat],'_+_['1.NzNat,'NzN':NzNat]] = '_<=_[
+    'NzN:NzNat,'NzN':NzNat] [none] .
 eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
 eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
+eq '_<_['_+_['1.NzNat,'NzN:NzNat],'_+_['1.NzNat,'NzN':NzNat]] = '_<_[
+    'NzN:NzNat,'NzN':NzNat] [none] .
 eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
 eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
 eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .
@@ -382,8 +386,12 @@ result SModule: mod 'BAKERY-FVP is
   op 'wait : nil -> 'NcMode [ctor] .
   none
   eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
+  eq '_<=_['_+_['1.NzNat,'NzN:NzNat],'_+_['1.NzNat,'NzN':NzNat]] = '_<=_[
+    'NzN:NzNat,'NzN':NzNat] [none] .
   eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
   eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
+  eq '_<_['_+_['1.NzNat,'NzN:NzNat],'_+_['1.NzNat,'NzN':NzNat]] = '_<_[
+    'NzN:NzNat,'NzN':NzNat] [none] .
   eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
   eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
   eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .

--- a/tests/tools/meta/mtransform.expected
+++ b/tests/tools/meta/mtransform.expected
@@ -96,14 +96,18 @@ op 'true : nil -> 'Bool [ctor special(
 ==========================================
 reduce in UNCONDITIONALIZE : stripConditions(asTemplate(upModule('BAKERY-FVP,
     true))) .
-rewrites: 78
+rewrites: 82
 result NeModuleDeclSet: (sorts 'BState ; 'Bool ; 'Mode ; 'Nat ; 'NcMode ;
     'NzNat .)
 subsort 'NcMode < 'Mode .
 subsort 'NzNat < 'Nat .
 eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
+eq '_<=_['_+_['1.NzNat,'NzN:NzNat],'_+_['1.NzNat,'NzN':NzNat]] = '_<=_[
+    'NzN:NzNat,'NzN':NzNat] [none] .
 eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
 eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
+eq '_<_['_+_['1.NzNat,'NzN:NzNat],'_+_['1.NzNat,'NzN':NzNat]] = '_<_[
+    'NzN:NzNat,'NzN':NzNat] [none] .
 eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
 eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
 eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .
@@ -179,7 +183,7 @@ result Bool: true
 ==========================================
 reduce in UNCONDITIONALIZE : wellFormed(fromTemplate('BAKERY-FVP,
     stripConditions(asTemplate(upModule('BAKERY-FVP, true))))) .
-rewrites: 82
+rewrites: 86
 result Bool: true
 ==========================================
 reduce in UNCONDITIONALIZE : wellFormed(fromTemplate('QLOCK-STATE,

--- a/tests/tools/meta/purification.expected
+++ b/tests/tools/meta/purification.expected
@@ -64,7 +64,7 @@ result Bool: true
 ==========================================
 reduce in TEST-PURIFY : moduleIntersect(asTemplate(natOrderMod), asTemplate(
     natOrderMod)) == asTemplate(natOrderMod) .
-rewrites: 30
+rewrites: 32
 result Bool: true
 ==========================================
 reduce in TEST-PURIFY : moduleIntersect(asTemplate(natListMod), asTemplate(

--- a/tests/tools/varsat/var-sat.expected
+++ b/tests/tools/varsat/var-sat.expected
@@ -1,6 +1,6 @@
 ==========================================
 reduce in TEST-NAT : var-sat(nat, 'true.Bool ?= upTerm(X < Y)) == true .
-rewrites: 2019
+rewrites: 2197
 result Bool: true
 ==========================================
 reduce in TEST-NAT : var-sat(nat, 'true.Bool != upTerm(X < Y)) == true .


### PR DESCRIPTION
This enables symbolic execution of several more equations in the EQFORM toolset, and ports over many of the tools from FOFORM to be used in EQFORM.