### PR TITLE
Updates to meta tools eqform, mtransform, and fvp/numbers

### DIFF
--- a/build
+++ b/build
@@ -119,6 +119,7 @@ build_test() {
 }
 
 build_test_load() {
+    build_tangle
     (   cd "$contrib_dir"
         make test-load "$@"
     )

--- a/contrib/tools/fvp.md/numbers.md
+++ b/contrib/tools/fvp.md/numbers.md
@@ -147,12 +147,15 @@ fmod FVP-NAT-PRED is
    protecting FVP-NAT .
    protecting FVP-BOOL-CTOR .
 
-    vars   N N' :   Nat .
-    var  NzN    : NzNat .
+    vars   N   N' :   Nat .
+    var  NzN      : NzNat .
 
     op _<_  : Nat Nat -> Bool .
     op _<=_ : Nat Nat -> Bool .
     ---------------------------
+    eq NzN + N <  NzN + N' = N <  N' .
+    eq NzN + N <= NzN + N' = N <= N' .
+
     eq N <  N + NzN  = true [variant] .
     eq N <= N +   N' = true [variant] .
 

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -634,3 +634,67 @@ fmod EQFORM-OPERATIONS is
   eq toUnifProb(T ?= T')           = T =? T' .
 endfm
 ```
+
+```maude
+fmod EQFORM-SET-OPERATIONS is
+  pr EQFORM-OPERATIONS .
+  pr EQFORM-SET .
+  pr EQFORM-CNF .
+  pr EQFORM-DNF .
+
+  var C : EqConj . var D : EqDisj . vars CF CG : NoTrueForm . vars DF DG : NoFalseForm .
+  var FS : FormSet . var F F' : Form . var UP : UnificationProblem .
+  var PEA : PosEqLit . var PELS : PosEqLitSet . var T T' : Term . var M : Module .
+
+  op wellFormed : Module FormSet -> Bool .
+  ----------------------------------------
+  eq wellFormed(M , F | F' | FS) = wellFormed(M,F) and-then wellFormed(M,F' | FS) .
+  eq wellFormed(M , mtFormSet)   = true .
+
+  op disj-join : FormSet -> [Form] .
+  op disj-join : FormSet -> [Form] .
+  ----------------------------------
+  eq disj-join(F | FS)    = F \/ disj-join(FS) .
+  eq disj-join(mtFormSet) = ff .
+
+  op conj-join : FormSet -> [Form] .
+  op conj-join : FormSet -> [Form] .
+  ----------------------------------
+  eq conj-join(F | FS)    = F /\ conj-join(FS) .
+  eq conj-join(mtFormSet) = tt .
+
+  op toDisjSet  :   Form -> [EqDisjSet] .
+  op toDisjSet' : EqDisj -> [EqDisjSet] .
+  ---------------------------------------
+  eq toDisjSet (F)      = toDisjSet'(cnf(F)) .
+  eq toDisjSet'(tt)     = mtFormSet .
+  eq toDisjSet'(ff)     = mtFormSet .
+  eq toDisjSet'(D /\ F) = D | toDisjSet'(F) .
+
+  op toConjSet  :   Form -> [EqConjSet] .
+  op toConjSet' : EqConj -> [EqConjSet] .
+  ---------------------------------------
+  eq toConjSet (F)      = toConjSet'(dnf(F)) .
+  eq toConjSet'(tt)     = mtFormSet .
+  eq toConjSet'(ff)     = mtFormSet .
+  eq toConjSet'(C \/ F) = C | toConjSet'(F) .
+
+  op toEqSet : PosEqLitSet -> EquationSet .
+  -----------------------------------------
+  eq toEqSet((T ?= T') | PELS) = (eq T = T' [none] .) toEqSet(PELS) .
+  eq toEqSet(mtFormSet)        = none .
+
+  op toPosEqLits : PosEqForm          -> PosEqLitSet .
+  op toPosEqLits : UnificationProblem -> PosEqLitSet .
+  ----------------------------------------------------
+  eq toPosEqLits(tt)       = mtFormSet .
+  eq toPosEqLits(ff)       = mtFormSet .
+  eq toPosEqLits(T ?= T')  = T ?= T' .
+  eq toPosEqLits(~ F)      = toPosEqLits(F) .
+  eq toPosEqLits(CF /\ CG) = toPosEqLits(CF) | toPosEqLits(CG) .
+  eq toPosEqLits(DF \/ DG) = toPosEqLits(DF) | toPosEqLits(DG) .
+
+  eq toPosEqLits(T =? T' /\ UP) = (T ?= T') | toPosEqLits(UP) .
+  eq toPosEqLits(T =? T')       = T ?= T' .
+endfm
+```

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -566,6 +566,17 @@ fmod EQFORM-SET is
   op (_|_) : EqFormNeSet     EqFormSet     -> EqFormNeSet    [ctor ditto] .
   op (_|_) : NormFormNeSet   NormFormSet   -> NormFormNeSet  [ctor ditto] .
   op (_|_) : FormNeSet       FormSet       -> FormNeSet      [ctor ditto] .
+
+  var S : Substitution . var NeSS : NeSubstitutionSet . var SS : SubstitutionSet .
+  var F : Form         . var FNeS : FormNeSet         . var FS : FormSet .
+
+  op _<<_ : FormSet SubstitutionSet -> [FormSet] .
+  ------------------------------------------------
+  eq mtFormSet  << SS = mtFormSet .
+  eq (F | FNeS) << SS = (F << SS) | (FNeS << SS) .
+
+  eq FS << .SubstitutionSet = mtFormSet .
+  eq FS << (S | NeSS)       = (FS << S) | (FS << NeSS) .
 endfm
 ```
 

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -106,6 +106,7 @@ generated for both the list and set functor assuming the 14 above).
 
 ```maude
 load terms.maude
+load ../meta/meta-aux.maude
 
 set include BOOL off .
 
@@ -565,5 +566,71 @@ fmod EQFORM-SET is
   op (_|_) : EqFormNeSet     EqFormSet     -> EqFormNeSet    [ctor ditto] .
   op (_|_) : NormFormNeSet   NormFormSet   -> NormFormNeSet  [ctor ditto] .
   op (_|_) : FormNeSet       FormSet       -> FormNeSet      [ctor ditto] .
+endfm
+```
+
+```maude
+fmod EQFORM-OPERATIONS is
+  pr EQFORM .
+  pr TERM-EXTRA . --- defines vars() : Term -> QidSet
+
+  vars CF CG : NoTrueForm . vars DF DG : NoFalseForm .
+  vars F F1 F2 : Form . vars PEC1 : PosEqConj .
+  vars M : Module . vars T T' : Term .
+
+  op  wellFormed : Module Form -> [Bool] .
+  op $wellFormed : Module Form -> [Bool] .
+  ----------------------------------------
+ ceq  wellFormed(M,F) = $wellFormed(M,F) if wellFormed(M) .
+
+  eq $wellFormed(M,tt)       = true .
+  eq $wellFormed(M,ff)       = true .
+  eq $wellFormed(M,~ F)      = $wellFormed(M,F) .
+  eq $wellFormed(M,CF /\ CG) = $wellFormed(M,CF) and-then $wellFormed(M,CG) .
+  eq $wellFormed(M,DF \/ DG) = $wellFormed(M,DF) and-then $wellFormed(M,DG) .
+
+  eq $wellFormed(M,T ?= T') = wellFormed(M,T) and-then wellFormed(M,T') and-then sameKind(M,leastSort(M,T),leastSort(M,T')) .
+  eq $wellFormed(M,T != T') = wellFormed(M,T) and-then wellFormed(M,T') and-then sameKind(M,leastSort(M,T),leastSort(M,T')) .
+
+  op normalize : Module Form -> [Form] .
+  --------------------------------------
+  eq normalize(M,tt)       = tt .
+  eq normalize(M,ff)       = ff .
+  eq normalize(M,~ F)      = ~ normalize(M,F) .
+  eq normalize(M,CF /\ CG) = normalize(M,CF) /\ normalize(M,CG) .
+  eq normalize(M,DF \/ DG) = normalize(M,DF) \/ normalize(M,DG) .
+
+  eq normalize(M,T ?= T') = getTerm(metaNormalize(M,T)) ?= getTerm(metaNormalize(M,T')) .
+  eq normalize(M,T != T') = getTerm(metaNormalize(M,T)) != getTerm(metaNormalize(M,T')) .
+
+  op reduce : Module Form -> [Form] .
+  -----------------------------------
+  eq reduce(M,tt)       = tt .
+  eq reduce(M,ff)       = ff .
+  eq reduce(M,~ F)      = ~ reduce(M,F) .
+  eq reduce(M,CF /\ CG) = reduce(M,CF) /\ reduce(M,CG) .
+  eq reduce(M,DF \/ DG) = reduce(M,DF) \/ reduce(M,DG) .
+
+  eq reduce(M,T ?= T') = getTerm(metaReduce(M,T)) ?= getTerm(metaReduce(M,T')) .
+  eq reduce(M,T != T') = getTerm(metaReduce(M,T)) != getTerm(metaReduce(M,T')) .
+
+  op vars : Form -> QidSet .
+  --------------------------
+  eq vars(tt)       = none .
+  eq vars(ff)       = none .
+  eq vars(~ F)      = vars(F) .
+  eq vars(CF /\ CG) = vars(CF) ; vars(CG) .
+  eq vars(DF \/ DG) = vars(DF) ; vars(DG) .
+
+  eq vars(T ?= T') = vars(T) ; vars(T') .
+  eq vars(T != T') = vars(T) ; vars(T') .
+
+  --- INP: PosConj
+  --- PRE: PosConj has no ff literals
+  --- OUT: UnificationProblem
+  op toUnifProb : PosEqConj -> UnificationProblem .
+  ------------------------------------------------
+  eq toUnifProb((T ?= T') /\ PEC1) = T =? T' /\ toUnifProb(PEC1) .
+  eq toUnifProb(T ?= T')           = T =? T' .
 endfm
 ```

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -203,14 +203,27 @@ fmod EQFORM-IMPL{X :: TRIV} is
   op _\/_ : Form{X}           Form{X}           -> Form{X}          [ditto] .
   ---------------------------------------------------------------------------
 
+  vars X X' : X$Elt .
   var EqL : EqLit{X} .
   vars F F' : Form{X} .
+
+  eq ~ tt = ff .
+  eq ~ ff = tt .
+
+  eq ff /\ ff = ff .
+  eq tt \/ tt = tt .
 
   eq ff /\ EqL = ff .
   eq tt \/ EqL = tt .
 
   eq EqL /\ EqL = EqL .
   eq EqL \/ EqL = EqL .
+
+  eq X ?= X = tt .
+  eq X != X = ff .
+
+  eq X ?= X' /\ X != X' = ff .
+  eq X ?= X' \/ X != X' = tt .
 
   --- Implication
   op _=>_  : Form{X} Form{X} -> Form{X} .

--- a/contrib/tools/meta.md/eqform.md
+++ b/contrib/tools/meta.md/eqform.md
@@ -207,30 +207,30 @@ fmod EQFORM-IMPL{X :: TRIV} is
   var EqL : EqLit{X} .
   vars F F' : Form{X} .
 
-  eq ~ tt = ff .
-  eq ~ ff = tt .
+  eq ~ tt = ff [variant] .
+  eq ~ ff = tt [variant] .
 
-  eq ff /\ ff = ff .
-  eq tt \/ tt = tt .
+  eq ff /\ ff = ff [variant] .
+  eq tt \/ tt = tt [variant] .
 
-  eq ff /\ EqL = ff .
-  eq tt \/ EqL = tt .
+  eq ff /\ EqL = ff [variant] .
+  eq tt \/ EqL = tt [variant] .
 
-  eq EqL /\ EqL = EqL .
-  eq EqL \/ EqL = EqL .
+  eq EqL /\ EqL = EqL [variant] .
+  eq EqL \/ EqL = EqL [variant] .
 
-  eq X ?= X = tt .
-  eq X != X = ff .
+  eq X ?= X = tt [variant] .
+  eq X != X = ff [variant] .
 
-  eq X ?= X' /\ X != X' = ff .
-  eq X ?= X' \/ X != X' = tt .
+  eq X ?= X' /\ X != X' = ff [variant] .
+  eq X ?= X' \/ X != X' = tt [variant] .
 
   --- Implication
   op _=>_  : Form{X} Form{X} -> Form{X} .
   op _<=>_ : Form{X} Form{X} -> Form{X} .
   ---------------------------------------
-  eq F  => F' = (~ F) \/ F' .
-  eq F <=> F' = (F => F') /\ (F' => F) .
+  eq F  => F' = (~ F) \/ F'            [variant] .
+  eq F <=> F' = (F => F') /\ (F' => F) [variant] .
 endfm
 
 view Term from TRIV to META-TERM is sort Elt to Term . endv

--- a/contrib/tools/meta.md/mtransform.md
+++ b/contrib/tools/meta.md/mtransform.md
@@ -112,28 +112,22 @@ fmod REVERSE-RULES is
 endfm
 ```
 
-Removing Conditional Equations/Rules
-------------------------------------
+Stripping Conditions
+--------------------
+
+Stripping conditions from the rules of a module creates an over-approximation of the transition system represented by them.
+Every rule application that could happen in the original system still can happen, but they may apply in more ways (when the condition would have stopped the rule application).
 
 ```maude
-fmod UNCONDITIONALIZE is
-   protecting META-LEVEL .
-   protecting MODULE-TEMPLATE .
+fmod STRIP-CONDITIONS is
+    protecting META-LEVEL .
+    protecting MODULE-TEMPLATE .
 
-    vars Q OP : Qid . var M : Module . var FM : FModule . vars S S' CS : Sort .
-    vars T T' C' : Term . vars A A' : Attr . var AS : AttrSet .
-    var C : Condition . var V : Variable .
-    var H : Header . var MD : ModuleDecl . var MDS : ModuleDeclSet .
-    vars NeMDS NeMDS' : NeModuleDeclSet .
-    var IDS : ImportDeclSet . var SDS : SortDeclSet .
-    var SSDS : SubsortDeclSet . var OPDS : OpDeclSet . var MAS : MembAxSet .
-    var EQS : EquationSet . var RLS : RuleSet . vars EqC EqC' : EqCondition .
-    vars NeRLS NeRLS' : NeRuleSet .
-```
+    var M : Module . var Q : Qid . vars T T' : Term . var C : Condition . var AS : AttrSet .
+    var IDS : ImportDeclSet . var SDS : SortDeclSet . var SSDS : SubsortDeclSet .
+    var OPDS : OpDeclSet . var MAS : MembAxSet . var EQS : EquationSet .
+    vars NeMDS NeMDS' : NeModuleDeclSet . var MDS : ModuleDeclSet .
 
-The following allow for simple manipulation of modules with coonditions, including removing and retrieving conditions for rules.
-
-```maude
     op stripConditions : ModuleDeclSet -> [ModuleDeclSet] .
     -------------------------------------------------------
     eq stripConditions(IDS SDS SSDS OPDS MAS EQS)   = IDS SDS SSDS OPDS MAS EQS .
@@ -153,14 +147,28 @@ The following allow for simple manipulation of modules with coonditions, includi
     op conditionFor : Qid Module -> [Condition] .
     ---------------------------------------------
     eq conditionFor(Q, M) = conditionFor(Q, asTemplate(M)) .
+endfm
 ```
 
-### Unconditionalize
+Unconditionalize Transformation
+-------------------------------
 
-The general algorithm for unconditionalizing rules with equational conditions follows.
-It's parametric in several operators and sorts (prefixed below with `#`) about the module which the conditions will be translated into.
+This operation will "internalize" the conditions of the rules in a conditional theory.
+It assumes that the theory is topmost to begin with, and augments it with a new operator which allows storing a constraint as well as the original state.
+Conditions are added to the right-hand-side of the rule as accumulated constraints.
+This transformation is parametric in several operators and sorts (prefixed below with `#`) about the module which the conditions will be translated into.
 
 ```maude
+fmod UNCONDITIONALIZE is
+   protecting META-LEVEL .
+   protecting MODULE-TEMPLATE .
+
+    var M : Module . var Q : Qid . vars T T' C' : Term . vars EqC EqC' : EqCondition .
+    var A : Attr . var AS : AttrSet . var CS : Sort . var V : Variable .
+    var IDS : ImportDeclSet . var SDS : SortDeclSet . var SSDS : SubsortDeclSet .
+    var OPDS : OpDeclSet . var MAS : MembAxSet . var EQS : EquationSet .
+    vars NeRLS NeRLS' : NeRuleSet . var RLS : RuleSet .
+
     op unconditionalize : ModuleDeclSet -> [ModuleDeclSet] .
     --------------------------------------------------------
    ceq unconditionalize(IDS SDS SSDS OPDS MAS EQS RLS)

--- a/contrib/tools/meta.md/mtransform.md
+++ b/contrib/tools/meta.md/mtransform.md
@@ -81,6 +81,37 @@ fmod BUILDIN-EQUATIONS is
 endfm
 ```
 
+Reversing Rules
+---------------
+
+This transformation will reverse both conditional and unconditional rules by swapping the LHS and the RHS.
+It leaves conditions *unchanged* on conditional rules.
+
+```maude
+fmod REVERSE-RULES is
+   protecting MODULE-TEMPLATE .
+
+    var IDS : ImportDeclSet . var SDS : SortDeclSet . var SSDS : SubsortDeclSet .
+    var OPDS : OpDeclSet . var MAS : MembAxSet . var EQS : EquationSet .
+    vars NeMDS NeMDS' : NeModuleDeclSet .
+
+    vars T T' : Term . var C : Condition . var AS : AttrSet .
+    var M : Module .
+
+    op reverseRules : ModuleDeclSet -> [ModuleDeclSet] .
+    ----------------------------------------------------
+    eq reverseRules(IDS SDS SSDS OPDS MAS EQS) = IDS SDS SSDS OPDS MAS EQS .
+    eq reverseRules(NeMDS NeMDS')              = reverseRules(NeMDS) reverseRules(NeMDS') .
+
+    eq reverseRules(  rl T => T'      [ AS ] . ) = (  rl T' => T      [ AS ] . ) .
+    eq reverseRules( crl T => T' if C [ AS ] . ) = ( crl T' => T if C [ AS ] . ) .
+
+    op reverseRules : Module -> [Module] .
+    --------------------------------------
+    eq reverseRules(M) = fromTemplate(getName(M), reverseRules(asTemplate(M))) .
+endfm
+```
+
 Removing Conditional Equations/Rules
 ------------------------------------
 

--- a/contrib/tools/meta.md/narrowing.md
+++ b/contrib/tools/meta.md/narrowing.md
@@ -13,7 +13,7 @@ Variant Sets
 ```maude
 fmod VARIANT-SET is
    protecting META-LEVEL .
-   protecting TERM-SET .
+   protecting SUBSTITUTION-SET .
 
     var N N' : Nat . var P : Parent . var B : Bool .
     var M : Module . var T : Term . var SUB : Substitution .
@@ -42,6 +42,13 @@ fmod VARIANT-SET is
     -------------------------------------
     eq getTerms(.VariantSet)            = .TermSet .
     eq getTerms({T, SUB, N, P, B} # VS) = T | getTerms(VS) .
+
+    op filterRenaming : VariantSet -> [VariantSet] .
+    ------------------------------------------------
+    eq filterRenaming({T , SUB , N , P , B}) = if not isRenaming(SUB) then {T, SUB, N, P, B} else .VariantSet fi .
+
+    eq filterRenaming(.VariantSet) = .VariantSet .
+    eq filterRenaming(V # V' # VS) = filterRenaming(V) # filterRenaming(V') # filterRenaming(VS) .
 endfm
 ```
 

--- a/contrib/tools/meta.md/narrowing.md
+++ b/contrib/tools/meta.md/narrowing.md
@@ -45,6 +45,28 @@ fmod VARIANT-SET is
 endfm
 ```
 
+Unification Sets
+----------------
+
+```maude
+fmod UNIFICATION is
+    protecting META-LEVEL .
+    protecting SUBSTITUTION-SET .
+
+    vars T T' : Term . vars N N' : Nat .
+    var M : Module . var SUB : Substitution .
+
+    op unifiers : Module Term Term -> [SubstitutionSet] .
+    -----------------------------------------------------
+    eq unifiers(M, T, T') = allUnifiers(M, T, T', 0) .
+
+    op allUnifiers : Module Term Term Nat -> [SubstitutionSet] .
+    ------------------------------------------------------------
+   ceq allUnifiers(M, T, T', N) = .SubstitutionSet                   if noUnifier    := metaUnify(M, T =? T', 0, N) .
+   ceq allUnifiers(M, T, T', N) = SUB | allUnifiers(M, T, T', N + 1) if { SUB , N' } := metaUnify(M, T =? T', 0, N) .
+endfm
+```
+
 Narrowing using Core Maude
 --------------------------
 

--- a/contrib/tools/meta.md/terms.md
+++ b/contrib/tools/meta.md/terms.md
@@ -90,7 +90,7 @@ fmod SUBSTITUTION-SET is
     op isRenaming : Substitution -> Bool .
     --------------------------------------
     eq isRenaming(none)         = true .
-    eq isRenaming(V <- T ; SUB) = (T :: Variable) and-then isRenaming(SUB) .
+    eq isRenaming(V <- T ; SUB) = (T :: Variable) and-then getType(V) == getType(T) and-then isRenaming(SUB) .
 endfm
 ```
 

--- a/tests/systems/imp.expected
+++ b/tests/systems/imp.expected
@@ -24,25 +24,25 @@ result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 * y |-> 1 +Nat
 ==========================================
 rewrite in IMP-TEST : < swap-sort(x ; y ; z) ~> done | x |-> 3 * y |-> 4 * z
     |-> 5 > .
-rewrites: 72
+rewrites: 82
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 * y |-> 1 +Nat 1 +Nat 1 +Nat
     1 * z |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 >
 ==========================================
 rewrite in IMP-TEST : < swap-sort(x ; z ; y) ~> done | x |-> 3 * y |-> 4 * z
     |-> 5 > .
-rewrites: 115
+rewrites: 125
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 * y |-> 1 +Nat 1 +Nat 1 +Nat
     1 +Nat 1 * z |-> 1 +Nat 1 +Nat 1 +Nat 1 >
 ==========================================
 rewrite in IMP-TEST : < swap-sort(y ; z ; x) ~> done | x |-> 3 * y |-> 4 * z
     |-> 5 > .
-rewrites: 158
+rewrites: 169
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 * y |-> 1 +Nat
     1 +Nat 1 * z |-> 1 +Nat 1 +Nat 1 +Nat 1 >
 ==========================================
 rewrite in IMP-TEST : < swap-sort(y ; z ; q ; x ; r) ~> done | x |-> 3 * y |->
     4 * z |-> 5 * q |-> 3 * r |-> 7 > .
-rewrites: 521
+rewrites: 573
 result RedContext: < done | x |-> 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 * y |-> 1 +Nat
     1 +Nat 1 * z |-> 1 +Nat 1 +Nat 1 * q |-> 1 +Nat 1 +Nat 1 +Nat 1 * r |-> 1
     +Nat 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 +Nat 1 >

--- a/tests/systems/thermostat.expected
+++ b/tests/systems/thermostat.expected
@@ -42,337 +42,337 @@ C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,off}
 
 Solution 2 (state 1)
-states: 2  rewrites: 65
+states: 2  rewrites: 85
 C:Conf --> < 1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 3 (state 2)
-states: 3  rewrites: 106
+states: 3  rewrites: 146
 C:Conf --> {1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 4 (state 3)
-states: 4  rewrites: 107
+states: 4  rewrites: 147
 C:Conf --> < 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 5 (state 4)
-states: 5  rewrites: 109
+states: 5  rewrites: 149
 C:Conf --> {1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,delay(on)}
 
 Solution 6 (state 5)
-states: 6  rewrites: 110
+states: 6  rewrites: 150
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1,delay(on) >
 
 Solution 7 (state 6)
-states: 7  rewrites: 112
+states: 7  rewrites: 152
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,delay(on)}
 
 Solution 8 (state 7)
-states: 8  rewrites: 113
+states: 8  rewrites: 153
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,delay(on) >
 
 Solution 9 (state 8)
-states: 9  rewrites: 115
+states: 9  rewrites: 155
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on)}
 
 Solution 10 (state 9)
-states: 10  rewrites: 116
+states: 10  rewrites: 156
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on) >
 
 Solution 11 (state 10)
-states: 11  rewrites: 118
+states: 11  rewrites: 158
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on)}
 
 Solution 12 (state 11)
-states: 12  rewrites: 119
+states: 12  rewrites: 159
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 13 (state 12)
-states: 13  rewrites: 123
+states: 13  rewrites: 163
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,on}
 
 Solution 14 (state 13)
-states: 14  rewrites: 194
+states: 14  rewrites: 274
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,on >
 
 Solution 15 (state 14)
-states: 15  rewrites: 198
+states: 15  rewrites: 278
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1,on}
 
 Solution 16 (state 15)
-states: 16  rewrites: 269
+states: 16  rewrites: 393
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1,on >
 
 Solution 17 (state 16)
-states: 17  rewrites: 273
+states: 17  rewrites: 397
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1,on}
 
 Solution 18 (state 17)
-states: 18  rewrites: 344
+states: 18  rewrites: 516
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,on >
 
 Solution 19 (state 18)
-states: 19  rewrites: 348
+states: 19  rewrites: 520
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 20 (state 19)
-states: 20  rewrites: 419
+states: 20  rewrites: 643
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 21 (state 20)
-states: 21  rewrites: 423
+states: 21  rewrites: 647
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 22 (state 21)
-states: 22  rewrites: 462
+states: 22  rewrites: 712
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 23 (state 22)
-states: 23  rewrites: 499
+states: 23  rewrites: 775
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 24 (state 23)
-states: 24  rewrites: 500
+states: 24  rewrites: 776
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 25 (state 24)
-states: 25  rewrites: 502
+states: 25  rewrites: 778
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 26 (state 25)
-states: 26  rewrites: 503
+states: 26  rewrites: 779
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 27 (state 26)
-states: 27  rewrites: 505
+states: 27  rewrites: 781
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 28 (state 27)
-states: 28  rewrites: 506
+states: 28  rewrites: 782
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,off >
 
 Solution 29 (state 28)
-states: 29  rewrites: 508
+states: 29  rewrites: 784
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1,off}
 
 Solution 30 (state 29)
-states: 30  rewrites: 555
+states: 30  rewrites: 850
 C:Conf --> < 1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 31 (state 30)
-states: 31  rewrites: 596
+states: 31  rewrites: 910
 C:Conf --> {1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 32 (state 31)
-states: 32  rewrites: 597
+states: 32  rewrites: 911
 C:Conf --> < 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1,delay(on) >
 
 Solution 33 (state 32)
-states: 33  rewrites: 599
+states: 33  rewrites: 913
 C:Conf --> {1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1,delay(on)}
 
 Solution 34 (state 33)
-states: 34  rewrites: 600
+states: 34  rewrites: 914
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1,delay(on) >
 
 Solution 35 (state 34)
-states: 35  rewrites: 602
+states: 35  rewrites: 916
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,delay(on)}
 
 Solution 36 (state 35)
-states: 36  rewrites: 603
+states: 36  rewrites: 917
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on) >
 
 Solution 37 (state 36)
-states: 37  rewrites: 605
+states: 37  rewrites: 919
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on)}
 
 Solution 38 (state 37)
-states: 38  rewrites: 606
+states: 38  rewrites: 920
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on) >
 
 Solution 39 (state 38)
-states: 39  rewrites: 608
+states: 39  rewrites: 922
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 40 (state 39)
-states: 40  rewrites: 609
+states: 40  rewrites: 923
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 41 (state 40)
-states: 41  rewrites: 613
+states: 41  rewrites: 927
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 42 (state 41)
-states: 42  rewrites: 684
+states: 42  rewrites: 1036
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on
     >
 
 Solution 43 (state 42)
-states: 43  rewrites: 688
+states: 43  rewrites: 1040
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,on}
 
 Solution 44 (state 43)
-states: 44  rewrites: 759
+states: 44  rewrites: 1153
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1,on >
 
 Solution 45 (state 44)
-states: 45  rewrites: 763
+states: 45  rewrites: 1157
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,on}
 
 Solution 46 (state 45)
-states: 46  rewrites: 834
+states: 46  rewrites: 1274
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1,on >
 
 Solution 47 (state 46)
-states: 47  rewrites: 838
+states: 47  rewrites: 1278
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 48 (state 47)
-states: 48  rewrites: 909
+states: 48  rewrites: 1399
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 49 (state 48)
-states: 49  rewrites: 913
+states: 49  rewrites: 1403
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 Solution 50 (state 49)
-states: 50  rewrites: 952
+states: 50  rewrites: 1468
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 51 (state 50)
-states: 51  rewrites: 989
+states: 51  rewrites: 1531
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 52 (state 51)
-states: 52  rewrites: 990
+states: 52  rewrites: 1532
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 53 (state 52)
-states: 53  rewrites: 992
+states: 53  rewrites: 1534
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 54 (state 53)
-states: 54  rewrites: 993
+states: 54  rewrites: 1535
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1 + 1,delay(off) >
 
 Solution 55 (state 54)
-states: 55  rewrites: 995
+states: 55  rewrites: 1537
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1 + 1,delay(off)}
 
 Solution 56 (state 55)
-states: 56  rewrites: 996
+states: 56  rewrites: 1538
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,off >
 
 Solution 57 (state 56)
-states: 57  rewrites: 998
+states: 57  rewrites: 1540
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,off}
 
 Solution 58 (state 57)
-states: 58  rewrites: 1045
+states: 58  rewrites: 1605
 C:Conf --> < 1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1 + 1 + 1,delay(on) >
 
 Solution 59 (state 58)
-states: 59  rewrites: 1086
+states: 59  rewrites: 1664
 C:Conf --> {1 + 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1 + 1 + 1,delay(on)}
 
 Solution 60 (state 59)
-states: 60  rewrites: 1087
+states: 60  rewrites: 1665
 C:Conf --> < 1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1 + 1 + 1,delay(on) >
 
 Solution 61 (state 60)
-states: 61  rewrites: 1089
+states: 61  rewrites: 1667
 C:Conf --> {1 + 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
     + 1,delay(on)}
 
 Solution 62 (state 61)
-states: 62  rewrites: 1090
+states: 62  rewrites: 1668
 C:Conf --> < 1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 +
     1,delay(on) >
 
 Solution 63 (state 62)
-states: 63  rewrites: 1092
+states: 63  rewrites: 1670
 C:Conf --> {1 + 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,
     delay(on)}
 
 Solution 64 (state 63)
-states: 64  rewrites: 1093
+states: 64  rewrites: 1671
 C:Conf --> < 1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(
     on) >
 
 Solution 65 (state 64)
-states: 65  rewrites: 1095
+states: 65  rewrites: 1673
 C:Conf --> {1,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 66 (state 65)
-states: 66  rewrites: 1096
+states: 66  rewrites: 1674
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)
     >
 
 Solution 67 (state 66)
-states: 67  rewrites: 1098
+states: 67  rewrites: 1676
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,delay(on)}
 
 Solution 68 (state 67)
-states: 68  rewrites: 1099
+states: 68  rewrites: 1677
 C:Conf --> < 0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on >
 
 Solution 69 (state 68)
-states: 69  rewrites: 1103
+states: 69  rewrites: 1681
 C:Conf --> {0,1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1,on}
 
 No more solutions.
-states: 69  rewrites: 1174
+states: 69  rewrites: 1788
 Bye.

--- a/tests/tools/fvp/numbers.expected
+++ b/tests/tools/fvp/numbers.expected
@@ -364,28 +364,28 @@ NzN:NzNat --> 1
 No more variants.
 rewrites: 2
 ==========================================
-get variants in FVP-NAT-PRED : NzN < N + NzN .
+get variants in FVP-NAT-PRED : NzN < NzN + N .
 
 Variant #1
-rewrites: 0
-Bool: #1:NzNat < #2:Nat + #1:NzNat
+rewrites: 1
+Bool: 0 < #2:Nat
 NzN --> #1:NzNat
 N --> #2:Nat
 
 Variant #2
-rewrites: 2
+rewrites: 3
 Bool: true
 NzN --> %1:NzNat
 N --> %2:NzNat
 
 Variant #3
-rewrites: 2
+rewrites: 3
 Bool: false
 NzN --> %1:NzNat
 N --> 0
 
 No more variants.
-rewrites: 2
+rewrites: 3
 ==========================================
 get variants in FVP-NAT-PRED : N < NzN .
 
@@ -398,28 +398,28 @@ NzN --> #2:NzNat
 Variant #2
 rewrites: 2
 Bool: true
-N --> %1:Nat
-NzN --> %1:Nat + %2:NzNat
+N --> %2:Nat
+NzN --> %1:NzNat + %2:Nat
 
 Variant #3
 rewrites: 2
 Bool: false
-N --> %2:Nat + %1:NzNat
+N --> %1:NzNat + %2:Nat
 NzN --> %1:NzNat
 
 No more variants.
 rewrites: 2
 ==========================================
-get variants in FVP-NAT-PRED : NzN <= N + NzN .
+get variants in FVP-NAT-PRED : NzN <= NzN + N .
 
 Variant #1
-rewrites: 1
+rewrites: 2
 Bool: true
 NzN --> #1:NzNat
 N --> #2:Nat
 
 No more variants.
-rewrites: 1
+rewrites: 2
 ==========================================
 get variants in FVP-NAT-PRED : N <= NzN .
 
@@ -433,19 +433,19 @@ Variant #2
 rewrites: 3
 Bool: true
 N --> %1:NzNat
-NzN --> %2:Nat + %1:NzNat
+NzN --> %1:NzNat + %2:Nat
 
 Variant #3
 rewrites: 3
 Bool: true
 N --> %1:Nat
-NzN --> %1:Nat + %2:NzNat
+NzN --> %2:NzNat + %1:Nat
 
 Variant #4
 rewrites: 3
 Bool: false
 N --> %1:NzNat + %2:NzNat
-NzN --> %1:NzNat
+NzN --> %2:NzNat
 
 No more variants.
 rewrites: 3

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -17,24 +17,25 @@ reduce in EQFORM-TEST : f1 << (
   'F:Foo <- 'F2:Foo ; 
   'I:Wop <- 'I2:Wop ; 
   'U:Stu <- 'U2:Stu) .
-rewrites: 95
-result NonTrivForm: ~ ('F2:Foo ?= 'G:Bar /\ 'F2:Foo != 'G:Bar) \/ ~ ('K:Foo ?=
-    'L:Bar /\ 'H:Baz ?= 'I2:Wop \/ 'H:Baz != 'I2:Wop)
+rewrites: 94
+result NonTrivForm: ~ ('B:Bar ?= 'foo.Foo /\ 'F2:Foo != 'f['bar.Bar]) \/ ~ (
+    'K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I2:Wop] \/ 'f['H:Baz] != 'f['f['I2:Wop]])
 ==========================================
 reduce in EQFORM-TEST : f2 << (
   'F:Foo <- 'F2:Foo ; 
   'I:Wop <- 'I2:Wop ; 
   'U:Stu <- 'U2:Stu) .
-rewrites: 121
-result NonTrivForm: ~ 'U2:Stu ?= 'W:Roc /\ ~ ('F2:Foo ?= 'G:Bar /\ 'F2:Foo !=
-    'G:Bar) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'I2:Wop \/ 'H:Baz != 'I2:Wop)
+rewrites: 123
+result NonTrivForm: ~ 'U2:Stu ?= 'W:Roc /\ ~ ('B:Bar ?= 'foo.Foo /\ 'F2:Foo !=
+    'f['bar.Bar]) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I2:Wop] \/ 'f['H:Baz]
+    != 'f['f['I2:Wop]])
 ==========================================
 reduce in EQFORM-TEST : f1 :: Form .
-rewrites: 7
+rewrites: 12
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : f2 :: Form .
-rewrites: 11
+rewrites: 19
 result Bool: true
 ==========================================
 reduce in EQFORM-TEST : ff .
@@ -54,45 +55,45 @@ rewrites: 0
 result Form: F:Form
 ==========================================
 reduce in EQFORM-TEST : nnf(f1) .
-rewrites: 15
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
-    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 20
+result EqForm: 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar
+    \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : nnf(f2) .
-rewrites: 21
-result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
-    'K:Foo != 'L:Bar \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 29
+result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo
+    \/ 'K:Foo != 'L:Bar \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : nef(f1) .
-rewrites: 17
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
-    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 22
+result EqForm: 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar
+    \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : nef(f2) .
-rewrites: 23
-result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/
-    'K:Foo != 'L:Bar \/ 'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 31
+result EqForm: 'U:Stu != 'W:Roc /\ 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo
+    \/ 'K:Foo != 'L:Bar \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : cnf(f1) .
-rewrites: 57
-result EqForm: ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/ 'F:Foo != 'G:Bar \/
-    'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'H:Baz !=
-    'I:Wop \/ 'K:Foo != 'L:Bar
+rewrites: 62
+result EqForm: ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz] ?= 'f['f['I:Wop]] \/
+    'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar
+    != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo != 'L:Bar
 ==========================================
 reduce in EQFORM-TEST : cnf(f2) .
-rewrites: 67
-result EqForm: 'U:Stu != 'W:Roc /\ ('F:Foo ?= 'G:Bar \/ 'H:Baz ?= 'I:Wop \/
-    'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'G:Bar \/ 'F:Foo !=
-    'G:Bar \/ 'H:Baz != 'I:Wop \/ 'K:Foo != 'L:Bar
+rewrites: 75
+result EqForm: 'U:Stu != 'W:Roc /\ ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz] ?= 'f[
+    'f['I:Wop]] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) /\ 'F:Foo ?= 'f[
+    'bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo != 'L:Bar
 ==========================================
 reduce in EQFORM-TEST : dnf(f1) .
-rewrites: 31
-result EqForm: 'F:Foo ?= 'G:Bar \/ 'F:Foo != 'G:Bar \/ 'K:Foo != 'L:Bar \/
-    'H:Baz ?= 'I:Wop /\ 'H:Baz != 'I:Wop
+rewrites: 36
+result EqForm: 'F:Foo ?= 'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar
+    \/ 'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop]
 ==========================================
 reduce in EQFORM-TEST : dnf(f2) .
-rewrites: 69
-result EqForm: ('F:Foo ?= 'G:Bar /\ 'U:Stu != 'W:Roc) \/ ('F:Foo != 'G:Bar /\
-    'U:Stu != 'W:Roc) \/ ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) \/ 'H:Baz ?=
-    'I:Wop /\ 'H:Baz != 'I:Wop /\ 'U:Stu != 'W:Roc
+rewrites: 77
+result EqForm: ('F:Foo ?= 'f['bar.Bar] /\ 'U:Stu != 'W:Roc) \/ ('B:Bar !=
+    'foo.Foo /\ 'U:Stu != 'W:Roc) \/ ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) \/
+    'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop] /\ 'U:Stu != 'W:Roc
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -179,4 +179,41 @@ reduce in EQFORM-TEST : toUnifProb(a /\ c /\ e) .
 rewrites: 7
 result UnificationProblem: 'B:Bar =? 'foo.Foo /\ 'H:Baz =? 'f['I:Wop] /\ 'U:Stu
     =? 'W:Roc
+==========================================
+reduce in EQFORM-TEST : toConjSet(t1 ?= t2) .
+rewrites: 16
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : toDisjSet(t1 ?= t2) .
+rewrites: 16
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : toConjSet(f1) .
+rewrites: 42
+result EqConjNeSet: ('F:Foo ?= 'f['bar.Bar]) | ('B:Bar != 'foo.Foo) | ('K:Foo
+    != 'L:Bar) | ('f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop])
+==========================================
+reduce in EQFORM-TEST : toDisjSet(f1) .
+rewrites: 66
+result EqDisjNeSet: ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz] ?= 'f['f['I:Wop]] \/
+    'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) | ('F:Foo ?= 'f['bar.Bar] \/ 'B:Bar
+    != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo != 'L:Bar)
+==========================================
+reduce in EQFORM-TEST : toConjSet(f2) .
+rewrites: 83
+result EqConjNeSet: ('F:Foo ?= 'f['bar.Bar] /\ 'U:Stu != 'W:Roc) | ('B:Bar !=
+    'foo.Foo /\ 'U:Stu != 'W:Roc) | ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) | (
+    'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop] /\ 'U:Stu != 'W:Roc)
+==========================================
+reduce in EQFORM-TEST : toDisjSet(f2) .
+rewrites: 80
+result EqDisjNeSet: ('U:Stu != 'W:Roc) | ('F:Foo ?= 'f['bar.Bar] \/ 'f['H:Baz]
+    ?= 'f['f['I:Wop]] \/ 'B:Bar != 'foo.Foo \/ 'K:Foo != 'L:Bar) | ('F:Foo ?=
+    'f['bar.Bar] \/ 'B:Bar != 'foo.Foo \/ 'H:Baz != 'f['I:Wop] \/ 'K:Foo !=
+    'L:Bar)
+==========================================
+reduce in EQFORM-TEST : toPosEqLits(f3) .
+rewrites: 10
+result PosEqLitNeSet: ('B:Bar ?= 'foo.Foo) | ('H:Baz ?= 'f['I:Wop]) | ('U:Stu
+    ?= 'W:Roc)
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -216,4 +216,14 @@ reduce in EQFORM-TEST : toPosEqLits(f3) .
 rewrites: 10
 result PosEqLitNeSet: ('B:Bar ?= 'foo.Foo) | ('H:Baz ?= 'f['I:Wop]) | ('U:Stu
     ?= 'W:Roc)
+==========================================
+reduce in EQFORM-TEST : (f1 | f2) << (
+  'H:Baz <- 'bar.Bar) | (
+  'H:Baz <- 'baz.Baz) == (f1 << (
+  'H:Baz <- 'baz.Baz)) | (f1 << (
+  'H:Baz <- 'bar.Bar)) | (f2 << (
+  'H:Baz <- 'bar.Bar)) | (f2 << (
+  'H:Baz <- 'baz.Baz)) .
+rewrites: 461
+result Bool: true
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -1,4 +1,219 @@
 ==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(B:Baz)) .
+
+Variant #1
+rewrites: 0
+Baz: f(f(#1:Baz))
+B:Baz --> #1:Baz
+
+Variant #2
+rewrites: 8
+Baz: baz
+B:Baz --> baz
+
+Variant #3
+rewrites: 8
+Baz: baz
+B:Baz --> bar
+
+Variant #4
+rewrites: 8
+Baz: baz
+B:Baz --> foo
+
+Variant #5
+rewrites: 8
+Wop: wop
+B:Baz --> wop
+
+No more variants.
+rewrites: 8
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(B:Bar)) .
+
+Variant #1
+rewrites: 0
+Baz: f(f(#1:Bar))
+B:Bar --> #1:Bar
+
+Variant #2
+rewrites: 4
+Baz: baz
+B:Bar --> bar
+
+Variant #3
+rewrites: 4
+Wop: wop
+B:Bar --> wop
+
+No more variants.
+rewrites: 4
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(W:Wop)) .
+
+Variant #1
+rewrites: 0
+Baz: f(f(#1:Wop))
+W:Wop --> #1:Wop
+
+Variant #2
+rewrites: 2
+Wop: wop
+W:Wop --> wop
+
+No more variants.
+rewrites: 2
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : f(f(B:Baz)) ?= f(f(B:Bar)) .
+
+Variant #1
+rewrites: 0
+PosEqLit{Baz}: f(f(#1:Baz)) ?= f(f(#2:Bar))
+B:Baz --> #1:Baz
+B:Bar --> #2:Bar
+
+Variant #2
+rewrites: 13
+TrueLit{Baz}: tt
+B:Baz --> %1:Bar
+B:Bar --> %1:Bar
+
+Variant #3
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Bar))
+B:Baz --> baz
+B:Bar --> %1:Bar
+
+Variant #4
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Bar))
+B:Baz --> bar
+B:Bar --> %1:Bar
+
+Variant #5
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Bar))
+B:Baz --> foo
+B:Bar --> %1:Bar
+
+Variant #6
+rewrites: 13
+PosEqLit{Baz}: wop ?= f(f(%1:Bar))
+B:Baz --> wop
+B:Bar --> %1:Bar
+
+Variant #7
+rewrites: 13
+PosEqLit{Baz}: baz ?= f(f(%1:Baz))
+B:Baz --> %1:Baz
+B:Bar --> bar
+
+Variant #8
+rewrites: 13
+PosEqLit{Baz}: wop ?= f(f(%1:Baz))
+B:Baz --> %1:Baz
+B:Bar --> wop
+
+Variant #9
+rewrites: 53
+TrueLit{Baz}: tt
+B:Baz --> baz
+B:Bar --> bar
+
+Variant #10
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> baz
+B:Bar --> wop
+
+Variant #11
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> bar
+B:Bar --> wop
+
+Variant #12
+rewrites: 53
+TrueLit{Baz}: tt
+B:Baz --> foo
+B:Bar --> bar
+
+Variant #13
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> foo
+B:Bar --> wop
+
+Variant #14
+rewrites: 53
+PosEqLit{Baz}: wop ?= baz
+B:Baz --> wop
+B:Bar --> bar
+
+No more variants.
+rewrites: 53
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : W:Wop ?= f(f(B:Baz)) .
+
+Variant #1
+rewrites: 0
+PosEqLit{Baz}: #1:Wop ?= f(f(#2:Baz))
+W:Wop --> #1:Wop
+B:Baz --> #2:Baz
+
+Variant #2
+rewrites: 8
+PosEqLit{Baz}: baz ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> baz
+
+Variant #3
+rewrites: 8
+PosEqLit{Baz}: baz ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> bar
+
+Variant #4
+rewrites: 8
+PosEqLit{Baz}: baz ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> foo
+
+Variant #5
+rewrites: 8
+PosEqLit{Baz}: wop ?= %1:Wop
+W:Wop --> %1:Wop
+B:Baz --> wop
+
+Variant #6
+rewrites: 9
+TrueLit{Baz}: tt
+W:Wop --> wop
+B:Baz --> wop
+
+No more variants.
+rewrites: 9
+==========================================
+get variants in EQFORM-TEST-INSTANTIATION : baz ?= f(B:Bar) .
+
+Variant #1
+rewrites: 0
+PosEqLit{Baz}: baz ?= f(#1:Bar)
+B:Bar --> #1:Bar
+
+Variant #2
+rewrites: 3
+TrueLit{Baz}: tt
+B:Bar --> bar
+
+Variant #3
+rewrites: 3
+PosEqLit{Baz}: wop ?= baz
+B:Bar --> wop
+
+No more variants.
+rewrites: 3
+==========================================
 reduce in EQFORM-TEST : ('_*_['Y:Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\
     'true.Bool != '_<_['Y:Nat,'Z:Nat]) << (
   'Y:Nat <- '3.Nat) == ('_*_['3.Nat,'X:Nat] ?= '_+_['1.Nat,'X:Nat] /\

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -96,4 +96,87 @@ rewrites: 77
 result EqForm: ('F:Foo ?= 'f['bar.Bar] /\ 'U:Stu != 'W:Roc) \/ ('B:Bar !=
     'foo.Foo /\ 'U:Stu != 'W:Roc) \/ ('K:Foo != 'L:Bar /\ 'U:Stu != 'W:Roc) \/
     'f['H:Baz] ?= 'f['f['I:Wop]] /\ 'H:Baz != 'f['I:Wop] /\ 'U:Stu != 'W:Roc
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+rewrites: 16
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), c) .
+rewrites: 13
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), f1) .
+rewrites: 64
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), f2) .
+rewrites: 82
+result Bool: true
+==========================================
+reduce in EQFORM-TEST : wellFormed(upModule('EQFORM-TEST-MODULE), f1 /\ '0.Term
+    ?= 'T:BadSort) .
+rewrites: 19
+result Bool: false
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('NAT), '0.Nat ?= 's_['s_['0.Nat]]) .
+rewrites: 7
+result PosEqLit: '0.Zero ?= 's_^2['0.Zero]
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+rewrites: 10
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+rewrites: 10
+result PosEqLit: 'bar.Bar ?= 'f['f['B:Baz]]
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), f(t2) ?= f(f(
+    t1))) .
+rewrites: 13
+result PosEqLit: 'f['bar.Bar] ?= 'f['f['f['f['B:Baz]]]]
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), f(t2) ?= f(f(
+    t1))) .
+rewrites: 14
+result PosEqLit: 'baz.Baz ?= 'f['f['f['f['B:Baz]]]]
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), f1) .
+rewrites: 43
+result NonTrivForm: ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo != 'f['bar.Bar]) \/ ~ (
+    'K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz] != 'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), f1) .
+rewrites: 44
+result NonTrivForm: ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo != 'baz.Baz) \/ ~ ('K:Foo
+    ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz] != 'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : normalize(upModule('EQFORM-TEST-MODULE), f2) .
+rewrites: 57
+result NonTrivForm: ~ 'U:Stu ?= 'W:Roc /\ ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo !=
+    'f['bar.Bar]) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz]
+    != 'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : reduce(upModule('EQFORM-TEST-MODULE), f2) .
+rewrites: 58
+result NonTrivForm: ~ 'U:Stu ?= 'W:Roc /\ ~ ('B:Bar ?= 'foo.Foo /\ 'F:Foo !=
+    'baz.Baz) \/ ~ ('K:Foo ?= 'L:Bar /\ 'H:Baz ?= 'f['I:Wop] \/ 'f['H:Baz] !=
+    'f['f['I:Wop]])
+==========================================
+reduce in EQFORM-TEST : vars('0.Nat ?= 's_['s_['X:Nat]]) .
+rewrites: 5
+result Variable: 'X:Nat
+==========================================
+reduce in EQFORM-TEST : vars(f1) .
+rewrites: 38
+result NeQidSet: 'B:Bar ; 'F:Foo ; 'H:Baz ; 'I:Wop ; 'K:Foo ; 'L:Bar
+==========================================
+reduce in EQFORM-TEST : vars(f2) .
+rewrites: 50
+result NeQidSet: 'B:Bar ; 'F:Foo ; 'H:Baz ; 'I:Wop ; 'K:Foo ; 'L:Bar ; 'U:Stu ;
+    'W:Roc
+==========================================
+reduce in EQFORM-TEST : toUnifProb(a /\ c /\ e) .
+rewrites: 7
+result UnificationProblem: 'B:Bar =? 'foo.Foo /\ 'H:Baz =? 'f['I:Wop] /\ 'U:Stu
+    =? 'W:Roc
 Bye.

--- a/tests/tools/meta/eqform.expected
+++ b/tests/tools/meta/eqform.expected
@@ -38,6 +38,22 @@ reduce in EQFORM-TEST : f2 :: Form .
 rewrites: 19
 result Bool: true
 ==========================================
+reduce in EQFORM-TEST : tt .
+rewrites: 0
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : tt \/ tt .
+rewrites: 1
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : ff /\ ff .
+rewrites: 1
+result FalseLit: ff
+==========================================
+reduce in EQFORM-TEST : ff .
+rewrites: 0
+result FalseLit: ff
+==========================================
 reduce in EQFORM-TEST : ff .
 rewrites: 0
 result FalseLit: ff
@@ -53,6 +69,22 @@ result Form: F:Form
 reduce in EQFORM-TEST : F:Form .
 rewrites: 0
 result Form: F:Form
+==========================================
+reduce in EQFORM-TEST : 'B:Bar ?= 'foo.Foo /\ 'B:Bar != 'foo.Foo .
+rewrites: 1
+result FalseLit: ff
+==========================================
+reduce in EQFORM-TEST : 'B:Bar ?= 'foo.Foo \/ 'B:Bar != 'foo.Foo .
+rewrites: 1
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : t1 ?= t1 .
+rewrites: 4
+result TrueLit: tt
+==========================================
+reduce in EQFORM-TEST : t1 != t1 .
+rewrites: 4
+result FalseLit: ff
 ==========================================
 reduce in EQFORM-TEST : nnf(f1) .
 rewrites: 20

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -27,6 +27,7 @@ fmod EQFORM-TEST is
   inc EQFORM-LIST .
   inc EQFORM-SET .
   inc EQFORM-OPERATIONS .
+  inc EQFORM-SET-OPERATIONS .
 
   var T : Term .
 
@@ -52,6 +53,9 @@ fmod EQFORM-TEST is
 
   op f2 : -> Form .
   eq f2 = (f1 /\ ~ e) /\ (d \/ tt) .
+
+  op f3 : -> Form .
+  eq f3 = (a /\ c) \/ e .
 endfm
 
 --- substitutions
@@ -112,3 +116,14 @@ reduce vars(f1) .
 reduce vars(f2) .
 
 reduce toUnifProb(a /\ c /\ e) .
+
+reduce toConjSet(t1 ?= t2) .
+reduce toDisjSet(t1 ?= t2) .
+
+reduce toConjSet(f1) .
+reduce toDisjSet(f1) .
+
+reduce toConjSet(f2) .
+reduce toDisjSet(f2) .
+
+reduce toPosEqLits(f3) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -15,11 +15,25 @@ fmod EQFORM-TEST-MODULE is
 
     op f : Baz -> Baz .
     -------------------
-    eq f(baz) = baz .
-    eq f(bar) = baz .
-    eq f(foo) = bar .
-    eq f(wop) = wop .
+    eq f(baz) = baz [variant] .
+    eq f(bar) = baz [variant] .
+    eq f(foo) = bar [variant] .
+    eq f(wop) = wop [variant] .
 endfm
+
+view Baz from TRIV to EQFORM-TEST-MODULE is sort Elt to Baz . endv
+
+fmod EQFORM-TEST-INSTANTIATION is
+    protecting EQFORM-IMPL{Baz} .
+endfm
+
+get variants f(f(B:Baz)) .
+get variants f(f(B:Bar)) .
+get variants f(f(W:Wop)) .
+
+get variants f(f(B:Baz)) ?= f(f(B:Bar)) .
+get variants f(f(B:Baz)) ?= W:Wop .
+get variants baz ?= f(B:Bar) .
 
 fmod EQFORM-TEST is
   inc EQFORM-CNF .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -127,3 +127,10 @@ reduce toConjSet(f2) .
 reduce toDisjSet(f2) .
 
 reduce toPosEqLits(f3) .
+
+reduce (f1 | f2) << (('H:Baz <- 'baz.Baz) | ('H:Baz <- 'bar.Bar))
+    == ( ( f1 << ('H:Baz <- 'baz.Baz) )
+       | ( f1 << ('H:Baz <- 'bar.Bar) )
+       | ( f2 << ('H:Baz <- 'baz.Baz) )
+       | ( f2 << ('H:Baz <- 'bar.Bar) )
+       ) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -26,6 +26,7 @@ fmod EQFORM-TEST is
   inc EQFORM-DNF .
   inc EQFORM-LIST .
   inc EQFORM-SET .
+  inc EQFORM-OPERATIONS .
 
   var T : Term .
 
@@ -87,3 +88,27 @@ reduce cnf(f2) .
 
 reduce dnf(f1) .
 reduce dnf(f2) .
+
+--- testing operations
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), c) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), f1) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), f2) .
+reduce wellFormed(upModule('EQFORM-TEST-MODULE), f1 /\ 'T:BadSort ?= '0.Term) .
+
+reduce normalize(upModule('NAT), 's_['s_['0.Nat]] ?= '0.Nat) .
+
+reduce normalize(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), t1 ?= t2) .
+reduce normalize(upModule('EQFORM-TEST-MODULE), f(f(t1)) ?= f(t2)) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), f(f(t1)) ?= f(t2)) .
+reduce normalize(upModule('EQFORM-TEST-MODULE), f1) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), f1) .
+reduce normalize(upModule('EQFORM-TEST-MODULE), f2) .
+reduce    reduce(upModule('EQFORM-TEST-MODULE), f2) .
+
+reduce vars('s_ ['s_['X:Nat]] ?= '0.Nat) .
+reduce vars(f1) .
+reduce vars(f2) .
+
+reduce toUnifProb(a /\ c /\ e) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -73,12 +73,25 @@ reduce f1 :: Form .
 reduce f2 :: Form .
 
 --- testing identities
+reduce tt /\ tt .
+reduce tt \/ tt .
+
+reduce ff /\ ff .
+reduce ff \/ ff .
+
 reduce tt /\ ff .
 reduce tt \/ ff .
 
 --- testing idempotency
 reduce tt /\ F:Form .
 reduce ff \/ F:Form .
+
+--- simplifications
+reduce 'B:Bar ?= 'foo.Foo /\ 'B:Bar != 'foo.Foo .
+reduce 'B:Bar ?= 'foo.Foo \/ 'B:Bar != 'foo.Foo .
+
+reduce t1 ?= t1 .
+reduce t1 != t1 .
 
 --- testing transformations
 reduce nnf(f1) .

--- a/tests/tools/meta/eqform.maude
+++ b/tests/tools/meta/eqform.maude
@@ -1,18 +1,49 @@
 load ../../../contrib/tools/meta/eqform.maude
 
+fmod EQFORM-TEST-MODULE is
+    sorts Foo Bar Baz Wop Stu Roc .
+    -------------------------------
+    subsorts Wop < Foo Bar < Baz .
+    subsorts Roc < Stu .
+
+    op wop : -> Wop .
+    op foo : -> Foo .
+    op bar : -> Bar .
+    op baz : -> Baz .
+    op roc : -> Roc .
+    op stu : -> Stu .
+
+    op f : Baz -> Baz .
+    -------------------
+    eq f(baz) = baz .
+    eq f(bar) = baz .
+    eq f(foo) = bar .
+    eq f(wop) = wop .
+endfm
+
 fmod EQFORM-TEST is
   inc EQFORM-CNF .
   inc EQFORM-DNF .
   inc EQFORM-LIST .
   inc EQFORM-SET .
 
-  ops t1 t2 : -> Term .
-  ops a b c d e : -> EqLit .
+  var T : Term .
 
-  eq a = 'F:Foo ?= 'G:Bar .
-  eq b = 'F:Foo != 'G:Bar .
-  eq c = 'H:Baz ?= 'I:Wop .
-  eq d = 'H:Baz != 'I:Wop .
+  op f : Term -> Term .
+  ---------------------
+  eq f(T) = 'f[T] .
+
+  ops t1 t2 : -> Term .
+  ---------------------
+  eq t1 = f(f('B:Baz)) .
+  eq t2 = 'bar.Bar .
+
+  ops a b c d e : -> EqLit .
+  --------------------------
+  eq a = 'foo.Foo ?= 'B:Bar .
+  eq b = 'F:Foo != f('bar.Bar) .
+  eq c = 'H:Baz ?= f('I:Wop) .
+  eq d = f('H:Baz) != f(f('I:Wop)) .
   eq e = 'U:Stu ?= 'W:Roc .
 
   op f1 : -> Form .

--- a/tests/tools/meta/mtemplate.expected
+++ b/tests/tools/meta/mtemplate.expected
@@ -186,8 +186,12 @@ subsort 'NcMode < 'Mode .
 subsort 'NzNat < 'Nat .
 eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
 eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
+eq '_<=_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<=_['N:Nat,
+    'N':Nat] [none] .
 eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
 eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
+eq '_<_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<_['N:Nat,
+    'N':Nat] [none] .
 eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
 eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .
 eq 'max['N:Nat,'_+_['N:Nat,'M:Nat]] = '_+_['N:Nat,'M:Nat] [variant] .
@@ -383,8 +387,12 @@ result SModule: mod 'BAKERY-FVP is
   none
   eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
   eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
+  eq '_<=_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<=_['N:Nat,
+    'N':Nat] [none] .
   eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
   eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
+  eq '_<_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<_['N:Nat,
+    'N':Nat] [none] .
   eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
   eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .
   eq 'max['N:Nat,'_+_['N:Nat,'M:Nat]] = '_+_['N:Nat,'M:Nat] [variant] .

--- a/tests/tools/meta/mtransform.expected
+++ b/tests/tools/meta/mtransform.expected
@@ -458,4 +458,70 @@ endm
 reduce in THERMOSTAT-UNCONDITIONALIZED-TEST : wellFormed(M) .
 rewrites: 2
 result Bool: true
+==========================================
+reduce in THERMOSTAT-UNCONDITIONALIZED-TEST : wellFormed(M, init) .
+rewrites: 3
+result Bool: true
+==========================================
+reduce in THERMOSTAT-UNCONDITIONALIZED-TEST : narrowSteps(M, init) .
+rewrites: 85
+result NeNarrowStepResults: {'inmode-off : '_st_['<_`,_`,_>['%1:Nat,'_+_[
+    '%1:Nat,'%2:NzNat],'off.InMode],'_?=_['false.Bool,'_<_['_+_['%1:Nat,
+    '%2:NzNat],'_+_['bound.Nat,'min.Nat]]]],
+  'IM:InMode <- 'off.InMode ; 
+  'TIME:Nat <- '%1:Nat ; 
+  'TMP:Nat <- '_+_['%1:Nat,'%2:NzNat]} || {'inmode-off : '_st_['<_`,_`,_>[
+    '@1:Nat,'@2:Nat,'off.InMode],'_/\_['_?=_['true.Bool,'_<_['@1:Nat,'@2:Nat]],
+    '_?=_['false.Bool,'_<_['@2:Nat,'_+_['bound.Nat,'min.Nat]]]]],
+  'IM:InMode <- 'off.InMode ; 
+  'TIME:Nat <- '@1:Nat ; 
+  'TMP:Nat <- '@2:Nat} || {'inmode-off : '_st_['<_`,_`,_>['_+_['%1:Nat,
+    '%2:Nat],'%1:Nat,'off.InMode],'ff.FalseLit`{Bool`}],
+  'IM:InMode <- 'off.InMode ; 
+  'TIME:Nat <- '_+_['%1:Nat,'%2:Nat] ; 
+  'TMP:Nat <- '%1:Nat} || {'inmode-on : '_st_['<_`,_`,_>['%1:Nat,'_+_['%1:Nat,
+    '%2:NzNat],'on.InMode],'_?=_['false.Bool,'_<_['max.Nat,'_+_['bound.Nat,
+    '%1:Nat,'%2:NzNat]]]],
+  'IM:InMode <- 'on.InMode ; 
+  'TIME:Nat <- '%1:Nat ; 
+  'TMP:Nat <- '_+_['%1:Nat,'%2:NzNat]} || {'inmode-on : '_st_['<_`,_`,_>[
+    '@1:Nat,'@2:Nat,'on.InMode],'_/\_['_?=_['true.Bool,'_<_['@1:Nat,'@2:Nat]],
+    '_?=_['false.Bool,'_<_['max.Nat,'_+_['bound.Nat,'@2:Nat]]]]],
+  'IM:InMode <- 'on.InMode ; 
+  'TIME:Nat <- '@1:Nat ; 
+  'TMP:Nat <- '@2:Nat} || {'inmode-on : '_st_['<_`,_`,_>['_+_['%1:Nat,'%2:Nat],
+    '%1:Nat,'on.InMode],'ff.FalseLit`{Bool`}],
+  'IM:InMode <- 'on.InMode ; 
+  'TIME:Nat <- '_+_['%1:Nat,'%2:Nat] ; 
+  'TMP:Nat <- '%1:Nat} || {'turning-off : '_st_['<_`,_`,_>['time-until[
+    'off.InMode],'%1:Nat,'delay['off.InMode]],'ff.FalseLit`{Bool`}],
+  'IM:InMode <- 'on.InMode ; 
+  'TIME:Nat <- '_+_['%1:Nat,'%2:Nat] ; 
+  'TMP:Nat <- '%1:Nat} || {'turning-off : '_st_['<_`,_`,_>['time-until[
+    'off.InMode],'@2:Nat,'delay['off.InMode]],'_/\_['_?=_['true.Bool,'_<_[
+    'max.Nat,'_+_['bound.Nat,'@2:Nat]]],'_?=_['true.Bool,'_<_['@1:Nat,
+    '@2:Nat]]]],
+  'IM:InMode <- 'on.InMode ; 
+  'TIME:Nat <- '@1:Nat ; 
+  'TMP:Nat <- '@2:Nat} || {'turning-off : '_st_['<_`,_`,_>['time-until[
+    'off.InMode],'_+_['%1:Nat,'%2:NzNat],'delay['off.InMode]],'_?=_['true.Bool,
+    '_<_['max.Nat,'_+_['bound.Nat,'%1:Nat,'%2:NzNat]]]],
+  'IM:InMode <- 'on.InMode ; 
+  'TIME:Nat <- '%1:Nat ; 
+  'TMP:Nat <- '_+_['%1:Nat,'%2:NzNat]} || {'turning-on : '_st_['<_`,_`,_>[
+    'time-until['on.InMode],'%1:Nat,'delay['on.InMode]],'ff.FalseLit`{Bool`}],
+  'IM:InMode <- 'off.InMode ; 
+  'TIME:Nat <- '_+_['%1:Nat,'%2:Nat] ; 
+  'TMP:Nat <- '%1:Nat} || {'turning-on : '_st_['<_`,_`,_>['time-until[
+    'on.InMode],'@2:Nat,'delay['on.InMode]],'_/\_['_?=_['true.Bool,'_<_[
+    '@1:Nat,'@2:Nat]],'_?=_['true.Bool,'_<_['@2:Nat,'_+_['bound.Nat,
+    'min.Nat]]]]],
+  'IM:InMode <- 'off.InMode ; 
+  'TIME:Nat <- '@1:Nat ; 
+  'TMP:Nat <- '@2:Nat} || {'turning-on : '_st_['<_`,_`,_>['time-until[
+    'on.InMode],'_+_['%1:Nat,'%2:NzNat],'delay['on.InMode]],'_?=_['true.Bool,
+    '_<_['_+_['%1:Nat,'%2:NzNat],'_+_['bound.Nat,'min.Nat]]]],
+  'IM:InMode <- 'off.InMode ; 
+  'TIME:Nat <- '%1:Nat ; 
+  'TMP:Nat <- '_+_['%1:Nat,'%2:NzNat]}
 Bye.

--- a/tests/tools/meta/mtransform.expected
+++ b/tests/tools/meta/mtransform.expected
@@ -8,15 +8,19 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
 ==========================================
 reduce in REVERSE-RULES : reverseRules(asTemplate(upModule('BAKERY-FVP, true)))
     .
-rewrites: 78
+rewrites: 82
 result NeModuleDeclSet: (sorts 'BState ; 'Bool ; 'Mode ; 'Nat ; 'NcMode ;
     'NzNat .)
 subsort 'NcMode < 'Mode .
 subsort 'NzNat < 'Nat .
 eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
 eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
+eq '_<=_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<=_['N:Nat,
+    'N':Nat] [none] .
 eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
 eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
+eq '_<_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<_['N:Nat,
+    'N':Nat] [none] .
 eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
 eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .
 eq 'max['N:Nat,'_+_['N:Nat,'M:Nat]] = '_+_['N:Nat,'M:Nat] [variant] .
@@ -73,7 +77,7 @@ result Bool: true
 ==========================================
 reduce in REVERSE-RULES : reverseRules(reverseRules(asTemplate(upModule(
     'BAKERY-FVP, true)))) == asTemplate(upModule('BAKERY-FVP, true)) .
-rewrites: 154
+rewrites: 162
 result Bool: true
 Warning: sort declarations for operator resolveNames failed preregularity check
     on 6 out of 40 sort tuples. First such tuple is (Type).
@@ -173,15 +177,19 @@ op 'true : nil -> 'Bool [ctor special(
 ==========================================
 reduce in STRIP-CONDITIONS : stripConditions(asTemplate(upModule('BAKERY-FVP,
     true))) .
-rewrites: 78
+rewrites: 82
 result NeModuleDeclSet: (sorts 'BState ; 'Bool ; 'Mode ; 'Nat ; 'NcMode ;
     'NzNat .)
 subsort 'NcMode < 'Mode .
 subsort 'NzNat < 'Nat .
 eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
 eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
+eq '_<=_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<=_['N:Nat,
+    'N':Nat] [none] .
 eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
 eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
+eq '_<_['_+_['N:Nat,'NzN:NzNat],'_+_['N':Nat,'NzN:NzNat]] = '_<_['N:Nat,
+    'N':Nat] [none] .
 eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
 eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .
 eq 'max['N:Nat,'_+_['N:Nat,'M:Nat]] = '_+_['N:Nat,'M:Nat] [variant] .
@@ -236,7 +244,7 @@ result Bool: true
 ==========================================
 reduce in STRIP-CONDITIONS : wellFormed(fromTemplate('BAKERY-FVP,
     stripConditions(asTemplate(upModule('BAKERY-FVP, true))))) .
-rewrites: 82
+rewrites: 86
 result Bool: true
 ==========================================
 reduce in STRIP-CONDITIONS : wellFormed(fromTemplate('QLOCK-STATE,

--- a/tests/tools/meta/mtransform.expected
+++ b/tests/tools/meta/mtransform.expected
@@ -6,6 +6,83 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     of 17576 sort triples. First such triple is (ModuleDeclSet, SortDeclSet,
     SortDeclSet).
 ==========================================
+reduce in REVERSE-RULES : reverseRules(asTemplate(upModule('BAKERY-FVP, true)))
+    .
+rewrites: 78
+result NeModuleDeclSet: (sorts 'BState ; 'Bool ; 'Mode ; 'Nat ; 'NcMode ;
+    'NzNat .)
+subsort 'NcMode < 'Mode .
+subsort 'NzNat < 'Nat .
+eq '_<=_['N:Nat,'_+_['N:Nat,'N':Nat]] = 'true.Bool [variant] .
+eq '_<=_['_+_['N:Nat,'NzN:NzNat],'N:Nat] = 'false.Bool [variant] .
+eq '_<_['N:Nat,'_+_['N:Nat,'NzN:NzNat]] = 'true.Bool [variant] .
+eq '_<_['_+_['N:Nat,'N':Nat],'N:Nat] = 'false.Bool [variant] .
+eq '_monus_['N:Nat,'_+_['N:Nat,'M:Nat]] = '0.Nat [variant] .
+eq '_monus_['_+_['N:Nat,'M:Nat],'N:Nat] = 'M:Nat [variant] .
+eq 'max['N:Nat,'_+_['N:Nat,'M:Nat]] = '_+_['N:Nat,'M:Nat] [variant] .
+eq 'min['N:Nat,'_+_['N:Nat,'M:Nat]] = 'N:Nat [variant] .
+eq 's['N:Nat] = '_+_['1.NzNat,'N:Nat] [variant] .
+eq 'sd['N:Nat,'_+_['N:Nat,'M:Nat]] = 'M:Nat [variant] .
+rl '<_`,_`,_`,_>['P:Mode,'0.Nat,'crit.Mode,'Y:Nat] => '<_`,_`,_`,_>['P:Mode,
+    '0.Nat,'wait.NcMode,'Y:Nat] [label('p2_wait1)] .
+rl '<_`,_`,_`,_>['P:Mode,'X:Nat,'sleep.NcMode,'0.Nat] => '<_`,_`,_`,_>['P:Mode,
+    'X:Nat,'crit.Mode,'Y:Nat] [label('p2_crit)] .
+rl '<_`,_`,_`,_>['P:Mode,'X:Nat,'wait.NcMode,'_+_['1.NzNat,'X:Nat]] =>
+    '<_`,_`,_`,_>['P:Mode,'X:Nat,'sleep.NcMode,'Y:Nat] [label('p2_sleep)] .
+rl '<_`,_`,_`,_>['crit.Mode,'X:Nat,'Q:Mode,'0.Nat] => '<_`,_`,_`,_>[
+    'wait.NcMode,'X:Nat,'Q:Mode,'0.Nat] [label('p1_wait1)] .
+rl '<_`,_`,_`,_>['sleep.NcMode,'0.Nat,'Q:Mode,'Y:Nat] => '<_`,_`,_`,_>[
+    'crit.Mode,'X:Nat,'Q:Mode,'Y:Nat] [label('p1_crit)] .
+rl '<_`,_`,_`,_>['wait.NcMode,'_+_['1.NzNat,'Y:Nat],'Q:Mode,'Y:Nat] =>
+    '<_`,_`,_`,_>['sleep.NcMode,'X:Nat,'Q:Mode,'Y:Nat] [label('p1_sleep)] .
+op '0 : nil -> 'Nat [ctor] .
+op '1 : nil -> 'NzNat [ctor] .
+op '<_`,_`,_`,_> : 'Mode 'Nat 'Mode 'Nat -> 'BState [ctor] .
+op '_+_ : 'Nat 'Nat -> 'Nat [assoc comm ctor id('0.Nat)] .
+op '_+_ : 'Nat 'NzNat -> 'NzNat [assoc comm ctor id('0.Nat)] .
+op '_<=_ : 'Nat 'Nat -> 'Bool [none] .
+op '_<_ : 'Nat 'Nat -> 'Bool [none] .
+op '_monus_ : 'Nat 'Nat -> 'Nat [none] .
+op 'crit : nil -> 'Mode [ctor] .
+op 'false : nil -> 'Bool [ctor special(
+    id-hook('SystemFalse, nil))] .
+op 'max : 'Nat 'Nat -> 'Nat [assoc comm] .
+op 'min : 'Nat 'Nat -> 'Nat [assoc comm] .
+op 's : 'Nat -> 'Nat [none] .
+op 'sd : 'Nat 'Nat -> 'Nat [comm] .
+op 'sleep : nil -> 'NcMode [ctor] .
+op 'true : nil -> 'Bool [ctor special(
+    id-hook('SystemTrue, nil))] .
+op 'wait : nil -> 'NcMode [ctor] .
+crl '<_`,_`,_`,_>['P:Mode,'X:Nat,'crit.Mode,'Y:Nat] => '<_`,_`,_`,_>['P:Mode,
+    'X:Nat,'wait.NcMode,'Y:Nat] if '_<_['Y:Nat,'X:Nat] = 'true.Bool [label(
+    'p2_wait2)] .
+crl '<_`,_`,_`,_>['crit.Mode,'X:Nat,'Q:Mode,'Y:Nat] => '<_`,_`,_`,_>[
+    'wait.NcMode,'X:Nat,'Q:Mode,'Y:Nat] if '_<=_['X:Nat,'Y:Nat] = 'true.Bool [
+    label('p1_wait2)] .
+==========================================
+reduce in REVERSE-RULES : reverseRules(asTemplate(upModule('QLOCK-STATE,
+    true))) == asTemplate(upModule('QLOCK-STATE, true)) .
+rewrites: 5
+result Bool: true
+==========================================
+reduce in REVERSE-RULES : reverseRules(reverseRules(asTemplate(upModule(
+    'DIJKSTRA, true)))) == asTemplate(upModule('DIJKSTRA, true)) .
+rewrites: 216
+result Bool: true
+==========================================
+reduce in REVERSE-RULES : reverseRules(reverseRules(asTemplate(upModule(
+    'BAKERY-FVP, true)))) == asTemplate(upModule('BAKERY-FVP, true)) .
+rewrites: 154
+result Bool: true
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 6 out of 40 sort tuples. First such tuple is (Type).
+Warning: sort declarations for operator resolveNames failed preregularity check
+    on 1 out of 26 sort tuples. First such tuple is (NullDeclSet).
+Warning: ctor declarations for associative operator __ are conflict on 138 out
+    of 17576 sort triples. First such triple is (ModuleDeclSet, SortDeclSet,
+    SortDeclSet).
+==========================================
 reduce in UNCONDITIONALIZE : stripConditions(asTemplate(upModule('DIJKSTRA,
     true))) .
 rewrites: 110

--- a/tests/tools/meta/mtransform.expected
+++ b/tests/tools/meta/mtransform.expected
@@ -83,7 +83,7 @@ Warning: ctor declarations for associative operator __ are conflict on 138 out
     of 17576 sort triples. First such triple is (ModuleDeclSet, SortDeclSet,
     SortDeclSet).
 ==========================================
-reduce in UNCONDITIONALIZE : stripConditions(asTemplate(upModule('DIJKSTRA,
+reduce in STRIP-CONDITIONS : stripConditions(asTemplate(upModule('DIJKSTRA,
     true))) .
 rewrites: 110
 result NeModuleDeclSet: (sorts '2Proc ; '2ProcSet ; 'Bool ; 'CProc ; 'Conf ;
@@ -171,7 +171,7 @@ op 'safe? : 'ProcSet -> 'Bool [none] .
 op 'true : nil -> 'Bool [ctor special(
     id-hook('SystemTrue, nil))] .
 ==========================================
-reduce in UNCONDITIONALIZE : stripConditions(asTemplate(upModule('BAKERY-FVP,
+reduce in STRIP-CONDITIONS : stripConditions(asTemplate(upModule('BAKERY-FVP,
     true))) .
 rewrites: 78
 result NeModuleDeclSet: (sorts 'BState ; 'Bool ; 'Mode ; 'Nat ; 'NcMode ;
@@ -224,42 +224,22 @@ op 'true : nil -> 'Bool [ctor special(
     id-hook('SystemTrue, nil))] .
 op 'wait : nil -> 'NcMode [ctor] .
 ==========================================
-reduce in UNCONDITIONALIZE : stripConditions(asTemplate(upModule('QLOCK-STATE,
-    true))) .
-rewrites: 4
-result NeModuleDeclSet: (sorts 'Bool* ; 'Nat* ; 'NeQueue ; 'Pred ; 'Queue ;
-    'Soup .)
-subsort 'Nat* < 'NeQueue .
-subsort 'Nat* < 'Soup .
-subsort 'NeQueue < 'Queue .
-eq '_in_['N:Nat*,'N:Nat*] = 'true.Pred [variant] .
-eq '_in_['N:Nat*,'__['N:Nat*,'S:Soup]] = 'true.Pred [variant] .
-eq 'dupl['__['N:Nat*,'N:Nat*]] = 'true.Pred [variant] .
-eq 'dupl['__['N:Nat*,'N:Nat*,'S:Soup]] = 'true.Pred [variant] .
-op '0 : nil -> 'Nat* [ctor] .
-op '1 : nil -> 'Nat* [ctor] .
-op '_:+_ : 'Nat* 'Nat* -> 'Nat* [assoc comm ctor id('0.Nat*)] .
-op '_=/=_ : 'Pred 'Pred -> 'Bool* [ctor] .
-op '_@_ : 'NeQueue 'NeQueue -> 'NeQueue [assoc ctor] .
-op '__ : 'Soup 'Soup -> 'Soup [assoc comm ctor id('mt.Soup)] .
-op '_in_ : 'Nat* 'Soup -> 'Pred [ctor] .
-op 'dupl : 'Soup -> 'Pred [ctor] .
-op 'mt : nil -> 'Soup [ctor] .
-op 'nil : nil -> 'Queue [ctor] .
-op 'true : nil -> 'Pred [ctor] .
-op 'tt : nil -> 'Bool* [ctor] .
+reduce in STRIP-CONDITIONS : stripConditions(asTemplate(upModule('QLOCK-STATE,
+    true))) == asTemplate(upModule('QLOCK-STATE, true)) .
+rewrites: 5
+result Bool: true
 ==========================================
-reduce in UNCONDITIONALIZE : wellFormed(fromTemplate('DIJKSTRA,
+reduce in STRIP-CONDITIONS : wellFormed(fromTemplate('DIJKSTRA,
     stripConditions(asTemplate(upModule('DIJKSTRA, true))))) .
 rewrites: 114
 result Bool: true
 ==========================================
-reduce in UNCONDITIONALIZE : wellFormed(fromTemplate('BAKERY-FVP,
+reduce in STRIP-CONDITIONS : wellFormed(fromTemplate('BAKERY-FVP,
     stripConditions(asTemplate(upModule('BAKERY-FVP, true))))) .
 rewrites: 82
 result Bool: true
 ==========================================
-reduce in UNCONDITIONALIZE : wellFormed(fromTemplate('QLOCK-STATE,
+reduce in STRIP-CONDITIONS : wellFormed(fromTemplate('QLOCK-STATE,
     stripConditions(asTemplate(upModule('QLOCK-STATE, true))))) .
 rewrites: 8
 result Bool: true

--- a/tests/tools/meta/mtransform.maude
+++ b/tests/tools/meta/mtransform.maude
@@ -25,6 +25,15 @@ fmod META-LEVEL-NAT-RENAMED is
                            ) .
 endfm
 
+select REVERSE-RULES .
+
+reduce reverseRules(asTemplate(upModule('BAKERY-FVP, true))) .
+
+reduce reverseRules(asTemplate(upModule('QLOCK-STATE, true))) == asTemplate(upModule('QLOCK-STATE, true)) .
+
+reduce reverseRules(reverseRules(asTemplate(upModule('DIJKSTRA   , true)))) == asTemplate(upModule('DIJKSTRA    , true)) .
+reduce reverseRules(reverseRules(asTemplate(upModule('BAKERY-FVP , true)))) == asTemplate(upModule('BAKERY-FVP  , true)) .
+
 select UNCONDITIONALIZE .
 
 reduce stripConditions(asTemplate(upModule('DIJKSTRA    , true))) .

--- a/tests/tools/meta/mtransform.maude
+++ b/tests/tools/meta/mtransform.maude
@@ -3,6 +3,7 @@ load ../../../contrib/systems/bakery.maude
 load ../../../contrib/systems/qlock.maude
 load ../../../contrib/systems/oc.maude
 load ../../../contrib/systems/thermostat.maude
+load ../../../contrib/tools/meta/narrowing.maude
 load ../../../contrib/tools/meta/mtransform.maude
 
 fmod META-LEVEL-NAT-RENAMED is
@@ -64,13 +65,20 @@ reduce wellFormed(M) .
 
 fmod THERMOSTAT-UNCONDITIONALIZED-TEST is
    protecting UNCONDITIONALIZE-FVP-BOOL .
+   protecting NARROWING .
 
     eq #tSort = 'Conf .
 
     op M : -> Module [memo] .
     -------------------------
     eq M = unconditionalize(upModule('THERMOSTAT, false)) .
+
+    op init : -> Term .
+    -------------------
+    eq init = '_st_['`{_`,_`,_`}['TIME:Nat, 'TMP:Nat, 'IM:InMode], '_?=_['true.Bool, '_<_['TIME:Nat, 'TMP:Nat]]] .
 endfm
 
 reduce M .
 reduce wellFormed(M) .
+reduce wellFormed(M, init) .
+reduce narrowSteps(M, init) .

--- a/tests/tools/meta/mtransform.maude
+++ b/tests/tools/meta/mtransform.maude
@@ -5,14 +5,6 @@ load ../../../contrib/systems/oc.maude
 load ../../../contrib/systems/thermostat.maude
 load ../../../contrib/tools/meta/mtransform.maude
 
---- Module SUBTHEORY-ABSTRACTION
---- ============================
-
-select SUBTHEORY-ABSTRACTION .
-
---- Module UNCONDITIONALIZE
---- =======================
-
 fmod META-LEVEL-NAT-RENAMED is
    protecting META-LEVEL * ( op _+_  to _+ML_
                            , op sd   to sdML
@@ -34,11 +26,11 @@ reduce reverseRules(asTemplate(upModule('QLOCK-STATE, true))) == asTemplate(upMo
 reduce reverseRules(reverseRules(asTemplate(upModule('DIJKSTRA   , true)))) == asTemplate(upModule('DIJKSTRA    , true)) .
 reduce reverseRules(reverseRules(asTemplate(upModule('BAKERY-FVP , true)))) == asTemplate(upModule('BAKERY-FVP  , true)) .
 
-select UNCONDITIONALIZE .
+select STRIP-CONDITIONS .
 
 reduce stripConditions(asTemplate(upModule('DIJKSTRA    , true))) .
 reduce stripConditions(asTemplate(upModule('BAKERY-FVP  , true))) .
-reduce stripConditions(asTemplate(upModule('QLOCK-STATE , true))) .
+reduce stripConditions(asTemplate(upModule('QLOCK-STATE , true))) == asTemplate(upModule('QLOCK-STATE, true)) .
 
 reduce wellFormed(fromTemplate('DIJKSTRA    , stripConditions(asTemplate(upModule('DIJKSTRA    , true))))) .
 reduce wellFormed(fromTemplate('BAKERY-FVP  , stripConditions(asTemplate(upModule('BAKERY-FVP  , true))))) .

--- a/tests/tools/meta/narrowing.expected
+++ b/tests/tools/meta/narrowing.expected
@@ -125,6 +125,16 @@ reduce in NAT-HARNESS : getTerms(variants(##m##, init(7))) .
 rewrites: 13
 result Constant: 'true.Bool
 ==========================================
+reduce in NAT-HARNESS : unifiers(##m##, init(0), init(1)) .
+rewrites: 10
+result Substitution: 
+  'X:Nat <- '_+_['1.NzNat,'#1:Nat] ; 
+  'Y:Nat <- '#1:Nat
+==========================================
+reduce in NAT-HARNESS : unifiers(##m##, init(6), init(7)) .
+rewrites: 9
+result SubstitutionSet: .SubstitutionSet
+==========================================
 reduce in NARROWING : allNarrowSteps(upModule('EXT-CYCLE, true), 'f[
     'a.PreState], 0) .
 rewrites: 12

--- a/tests/tools/meta/narrowing.expected
+++ b/tests/tools/meta/narrowing.expected
@@ -100,11 +100,11 @@ result Variant: {'true.Bool,
   'Y:Nat <- '#2:Nat,2,none,false}
 ==========================================
 reduce in NAT-HARNESS : filterRenaming(variants(##m##, init(0))) .
-rewrites: 16
+rewrites: 32
 result VariantSet: .VariantSet
 ==========================================
 reduce in NAT-HARNESS : filterRenaming(variants(##m##, init(4))) .
-rewrites: 60
+rewrites: 108
 result VariantSet: {'false.Bool,
   'X:Nat <- '_+_['1.NzNat,'%1:Nat,'%2:Nat] ; 
   'Y:Nat <- '%1:Nat,2,0,false} #
@@ -116,7 +116,7 @@ result VariantSet: {'false.Bool,
   'Y:Nat <- '_+_['%1:Nat,'%2:NzNat],2,0,true}
 ==========================================
 reduce in NAT-HARNESS : filterRenaming(variants(##m##, init(5))) .
-rewrites: 60
+rewrites: 108
 result VariantSet: {'false.Bool,
   'Y:Nat <- '%1:Nat ; 
   'Z:NzNat <- '_+_['1.NzNat,'%1:Nat,'%2:Nat],2,0,false} #

--- a/tests/tools/meta/narrowing.expected
+++ b/tests/tools/meta/narrowing.expected
@@ -99,6 +99,34 @@ result Variant: {'true.Bool,
   'X:Nat <- '#1:Nat ; 
   'Y:Nat <- '#2:Nat,2,none,false}
 ==========================================
+reduce in NAT-HARNESS : filterRenaming(variants(##m##, init(0))) .
+rewrites: 16
+result VariantSet: .VariantSet
+==========================================
+reduce in NAT-HARNESS : filterRenaming(variants(##m##, init(4))) .
+rewrites: 60
+result VariantSet: {'false.Bool,
+  'X:Nat <- '_+_['1.NzNat,'%1:Nat,'%2:Nat] ; 
+  'Y:Nat <- '%1:Nat,2,0,false} #
+{'true.Bool,
+  'X:Nat <- '%1:Nat ; 
+  'Y:Nat <- '_+_['%1:Nat,'%2:Nat],2,0,true} #
+{'true.Bool,
+  'X:Nat <- '_+_['1.NzNat,'%1:Nat] ; 
+  'Y:Nat <- '_+_['%1:Nat,'%2:NzNat],2,0,true}
+==========================================
+reduce in NAT-HARNESS : filterRenaming(variants(##m##, init(5))) .
+rewrites: 60
+result VariantSet: {'false.Bool,
+  'Y:Nat <- '%1:Nat ; 
+  'Z:NzNat <- '_+_['1.NzNat,'%1:Nat,'%2:Nat],2,0,false} #
+{'true.Bool,
+  'Y:Nat <- '_+_['%1:Nat,'%2:NzNat] ; 
+  'Z:NzNat <- '_+_['1.NzNat,'%1:Nat],2,0,true} #
+{'true.Bool,
+  'Y:Nat <- '_+_['%2:Nat,'%1:NzNat] ; 
+  'Z:NzNat <- '%1:NzNat,2,0,true}
+==========================================
 reduce in NAT-HARNESS : getTerms(variants(##m##, init(0))) .
 rewrites: 10
 result Variable: '#1:Nat

--- a/tests/tools/meta/narrowing.maude
+++ b/tests/tools/meta/narrowing.maude
@@ -7,7 +7,7 @@ load ../../../contrib/tools/meta/narrowing.maude
 --- =================
 
 fmod NAT-HARNESS is
-   protecting NARROWING .
+   protecting NARROWING + UNIFICATION .
 
     op ##m## : ~> SModule [memo] .
     ------------------------------
@@ -54,6 +54,12 @@ reduce getTerms(variants(##m##, init(4))) .
 reduce getTerms(variants(##m##, init(5))) .
 reduce getTerms(variants(##m##, init(6))) .
 reduce getTerms(variants(##m##, init(7))) .
+
+--- Module `UNIFICATION`
+--- ====================
+
+reduce unifiers(##m##, init(0), init(1)) .
+reduce unifiers(##m##, init(6), init(7)) .
 
 --- Module `NARROWNG`
 --- =================

--- a/tests/tools/meta/narrowing.maude
+++ b/tests/tools/meta/narrowing.maude
@@ -37,8 +37,6 @@ reduce wellFormed(##m##, init(7)) .
 --- Module `VARIANT-SET`
 --- ====================
 
---- ### Module `NAT>`
-
 reduce variants(##m##, init(0)) .
 reduce variants(##m##, init(1)) .
 reduce variants(##m##, init(2)) .
@@ -47,6 +45,10 @@ reduce variants(##m##, init(4)) .
 reduce variants(##m##, init(5)) .
 reduce variants(##m##, init(6)) .
 reduce variants(##m##, init(7)) .
+
+reduce filterRenaming(variants(##m##, init(0))) .
+reduce filterRenaming(variants(##m##, init(4))) .
+reduce filterRenaming(variants(##m##, init(5))) .
 
 reduce getTerms(variants(##m##, init(0))) .
 reduce getTerms(variants(##m##, init(3))) .

--- a/tests/tools/meta/purification.expected
+++ b/tests/tools/meta/purification.expected
@@ -64,7 +64,7 @@ result Bool: true
 ==========================================
 reduce in TEST-PURIFY : moduleIntersect(asTemplate(natOrderMod), asTemplate(
     natOrderMod)) == asTemplate(natOrderMod) .
-rewrites: 30
+rewrites: 32
 result Bool: true
 ==========================================
 reduce in TEST-PURIFY : moduleIntersect(asTemplate(natListMod), asTemplate(

--- a/tests/tools/meta/terms.expected
+++ b/tests/tools/meta/terms.expected
@@ -4,20 +4,31 @@ rewrites: 1
 result Bool: true
 ==========================================
 reduce in SUBSTITUTION-SET : isRenaming(
-  'T:Foo <- 'B:Bar) .
-rewrites: 4
+  'T:Foo <- 'T2:Foo) .
+rewrites: 20
 result Bool: true
 ==========================================
 reduce in SUBSTITUTION-SET : isRenaming(
-  'T:Foo <- 'B:Bar ; 
+  'T:Foo <- 'B:Bar) .
+rewrites: 19
+result Bool: false
+==========================================
+reduce in SUBSTITUTION-SET : isRenaming(
+  'T:Foo <- 'T2:Foo ; 
   'X:Foo <- 'B:Bar) .
-rewrites: 7
+rewrites: 38
+result Bool: false
+==========================================
+reduce in SUBSTITUTION-SET : isRenaming(
+  'B:Bar <- 'B2:Bar ; 
+  'T:Foo <- 'T2:Foo) .
+rewrites: 39
 result Bool: true
 ==========================================
 reduce in SUBSTITUTION-SET : isRenaming(
   'T:Foo <- 'B:Bar ; 
   'X:Foo <- 'bar.Bar) .
-rewrites: 6
+rewrites: 19
 result Bool: false
 ==========================================
 reduce in SUBSTITUTION-SET : isRenaming(

--- a/tests/tools/meta/terms.maude
+++ b/tests/tools/meta/terms.maude
@@ -3,7 +3,9 @@ load ../../../contrib/tools/meta/terms.maude
 select SUBSTITUTION-SET .
 
 reduce isRenaming(none) .
+reduce isRenaming('T:Foo <- 'T2:Foo) .
 reduce isRenaming('T:Foo <- 'B:Bar) .
-reduce isRenaming('T:Foo <- 'B:Bar ; 'X:Foo <- 'B:Bar) .
+reduce isRenaming('T:Foo <- 'T2:Foo ; 'X:Foo <- 'B:Bar) .
+reduce isRenaming('T:Foo <- 'T2:Foo ; 'B:Bar <- 'B2:Bar) .
 reduce isRenaming('T:Foo <- 'B:Bar ; 'X:Foo <- 'bar.Bar) .
 reduce isRenaming('T:Foo <- 'bar.Bar) .

--- a/tests/tools/varsat/var-sat.expected
+++ b/tests/tools/varsat/var-sat.expected
@@ -1,6 +1,6 @@
 ==========================================
 reduce in TEST-NAT : var-sat(nat, 'true.Bool ?= upTerm(X < Y)) == true .
-rewrites: 2019
+rewrites: 2197
 result Bool: true
 ==========================================
 reduce in TEST-NAT : var-sat(nat, 'true.Bool != upTerm(X < Y)) == true .


### PR DESCRIPTION
These updates include:

-   Implementing several helpers in narrowing/variant manip modules.
-   Porting several tools from FOFORM over to EQFORM.
-   Enabling symbolic execution/simplification for more of the EQFORM data-structures.
-   Reducing the size of terms in predicates from FVP-INT.
-   Adding a `reverseRules` transformation to mtransform.
-   Cleaning up mtransform file.